### PR TITLE
Adding a demos folder and a resnet demo for forge-fe

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -1,0 +1,21 @@
+# TT-Forge Demos
+
+This directory contains demonstration examples for three different frontends available for Tenstorrent hardware:
+
+## Available Frontends
+
+### [`tt-forge-fe/`](tt-forge-fe/)
+The Frontend Engine (FE) provides a high-level interface for deploying popular deep learning models. It includes ready-to-use implementations of common CNN and NLP models like ResNet, MobileNet, and BERT.
+
+### [`tt-torch/`](https://github.com/tenstorrent/tt-torch) (Coming soon)
+A PyTorch-based frontend that enables seamless deployment of PyTorch models on Tenstorrent hardware. This frontend provides familiar PyTorch workflows while leveraging Tenstorrent's acceleration capabilities.
+
+### [`tt-xla/`](https://github.com/tenstorrent/tt-xla) (Coming soon)
+An XLA-based frontend that supports JAX and TensorFlow models. This enables users to deploy models from these frameworks directly to Tenstorrent hardware while maintaining their existing development workflow.
+
+Each frontend is designed to support different ML frameworks and workflows. Choose the frontend that best matches your needs:
+- Use `tt-forge-fe` for quick deployment of pre-optimized common models
+- Use `tt-torch` for PyTorch model deployment
+- Use `tt-xla` for JAX and TensorFlow model deployment
+
+For more information, visit our [GitHub repositories](https://github.com/tenstorrent) or check the README in each frontend's directory.

--- a/demos/tt-forge-fe/README.md
+++ b/demos/tt-forge-fe/README.md
@@ -1,0 +1,41 @@
+# TT-Forge-FE Model Demos
+
+This directory contains example implementations of popular deep learning models using TT-Forge-FE. These demos showcase how to use TT-Forge-FE to run inference on various computer vision and natural language processing models.
+
+## Installation
+
+Before running the demos, make sure you have TT-Forge-FE installed. You can install it using wheels from our latest release:
+
+1. Download the latest TT-Forge-FE release (includes both TVM and tt-Forge-fe wheels):
+   - Visit [TT-Forge Releases](https://github.com/tenstorrent/tt-forge/releases)
+
+2. Install the wheels:
+   ```bash
+   pip install *.whl
+   ```
+   Note: Run this command from the directory where you downloaded the wheels.
+
+## Available Demos
+
+| Model | Model Type | Description | Demo Code |
+|-------|------------|-------------|------------|
+| MobileNetV2 | CNN | Lightweight convolutional neural network for efficient image classification | [`cnn/mobile_netv2_demo.py`](cnn/mobile_netv2_demo.py) |
+| ResNet-50 | CNN | Deep residual network for image classification | [`cnn/resnet_50_demo.py`](cnn/resnet_50_demo.py) |
+| ViLT | CNN | Vision-and-Language Transformer for vision-language tasks | [`cnn/vilt_demo.py`](cnn/vilt_demo.py) |
+| BERT | NLP | Bidirectional Encoder Representations from Transformers for natural language understanding tasks | [`nlp/bert_demo.py`](nlp/bert_demo.py) |
+
+## Running the Demos
+
+Each demo can be run directly using Python. Navigate to the specific model directory and run the demo script:
+
+```bash
+python cnn/resnet_50_demo.py
+```
+
+If you encounter any issues or have questions, please file them at [github.com/tenstorrent/tt-forge/issues](https://github.com/tenstorrent/tt-forge/issues).
+
+## Additional Resources
+
+- [TT-Forge-FE Documentation](https://docs.tenstorrent.com/tt-forge-fe/)
+- [Getting Started Guide](https://docs.tenstorrent.com/tt-forge-fe/getting-started.html)
+- [TT-Forge-FE GitHub Repository](https://github.com/tenstorrent/tt-forge)

--- a/demos/tt-forge-fe/cnn/mobile_netv2_demo.py
+++ b/demos/tt-forge-fe/cnn/mobile_netv2_demo.py
@@ -1,0 +1,98 @@
+import torch
+import timm
+import requests
+from PIL import Image
+from torchvision import transforms
+import forge
+
+# Common ImageNet classes (subset)
+IMAGENET_CLASSES = {
+    281: 'tabby cat',
+    282: 'tiger cat',
+    283: 'Persian cat',
+    284: 'Siamese cat',
+    285: 'Egyptian cat',
+    258: 'Samoyed, Samoyede',  # White fluffy dog breed
+    259: 'Siberian husky',
+    260: 'German shepherd',
+    261: 'golden retriever',
+    262: 'Labrador retriever'
+}
+
+def load_image_from_url(url):
+    """Load and preprocess an image from a URL."""
+    return Image.open(requests.get(url, stream=True).raw).convert('RGB')
+
+def get_imagenet_transforms():
+    """Get standard ImageNet preprocessing transforms."""
+    return transforms.Compose([
+        transforms.Resize(256),
+        transforms.CenterCrop(224),
+        transforms.ToTensor(),
+        transforms.Normalize(mean=[0.485, 0.456, 0.406], 
+                           std=[0.229, 0.224, 0.225])
+    ])
+
+def run_mobilenet_inference(image_url=None, model_name="mobilenetv2_100"):
+    """Run inference with MobileNetV2 model.
+    
+    Args:
+        image_url (str): URL of the input image
+        model_name (str): Name of the MobileNetV2 model variant from timm
+        
+    Returns:
+        dict: Prediction result with class label and confidence
+    """
+    # Load model and preprocessing
+    model = timm.create_model(model_name, pretrained=True)
+    model.eval()
+    transform = get_imagenet_transforms()
+    
+    # Load and preprocess image
+    image = load_image_from_url(image_url)
+    input_tensor = transform(image).unsqueeze(0)
+    
+    # Create input sample for compilation
+    input_sample = [torch.rand(1, 3, 224, 224)]
+    
+    # Compile model with forge
+    compiled_model = forge.compile(model, input_sample)
+    
+    # Run inference
+    with torch.no_grad():
+        output = compiled_model(input_tensor)
+        # Ensure output is the right shape [1, num_classes]
+        if len(output[0].shape) == 1:
+            logits = output[0].unsqueeze(0)
+        else:
+            logits = output[0]
+            
+        # Get probabilities
+        probabilities = torch.nn.functional.softmax(logits, dim=1)
+        
+        # Get top prediction
+        confidence, class_idx = torch.max(probabilities[0], dim=0)
+        class_idx = class_idx.item()
+        confidence = confidence.item()
+    
+    # Get human-readable label
+    label = IMAGENET_CLASSES.get(class_idx, f"Class {class_idx}")
+    
+    return {
+        'label': label,
+        'confidence': confidence,
+        'class_idx': class_idx
+    }
+
+if __name__ == "__main__":
+    # Example usage with different images
+    test_images = [
+        "http://images.cocodataset.org/val2017/000000039769.jpg",  # Cat image
+        "https://raw.githubusercontent.com/pytorch/hub/master/images/dog.jpg"  # Dog image
+    ]
+    
+    for image_url in test_images:
+        print(f"\nProcessing image: {image_url}")
+        result = run_mobilenet_inference(image_url=image_url)
+        print(f"Prediction: {result['label']} (class {result['class_idx']})")
+        print(f"Confidence: {result['confidence']:.3f}")

--- a/demos/tt-forge-fe/cnn/mobile_netv2_demo.py
+++ b/demos/tt-forge-fe/cnn/mobile_netv2_demo.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 import timm
 import requests

--- a/demos/tt-forge-fe/cnn/resnet_50_demo.py
+++ b/demos/tt-forge-fe/cnn/resnet_50_demo.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+# ResNet Demo Script
+
+import os
+
+import forge
+import requests
+import torch
+from PIL import Image
+from transformers import AutoFeatureExtractor, ResNetForImageClassification
+
+
+def run_resnet_pytorch(variant="microsoft/resnet-50", batch_size=1):
+
+    # Load ResNet feature extractor and model checkpoint from HuggingFace
+    model_ckpt = variant
+    feature_extractor = AutoFeatureExtractor.from_pretrained(model_ckpt)
+    model = ResNetForImageClassification.from_pretrained(model_ckpt)
+
+    # Load data sample
+    url = "https://images.rawpixel.com/image_1300/cHJpdmF0ZS9sci9pbWFnZXMvd2Vic2l0ZS8yMDIyLTA1L3BkMTA2LTA0Ny1jaGltXzEuanBn.jpg"
+    image = Image.open(requests.get(url, stream=True).raw)
+    label = ["tiger"] * batch_size
+
+    # Data preprocessing
+    inputs = feature_extractor(image, return_tensors="pt")
+    pixel_values = [inputs["pixel_values"]] * batch_size
+    batch_input = torch.cat(pixel_values, dim=0)
+
+    # Run inference on Tenstorrent device
+    framework_model = ResNetForImageClassification.from_pretrained("microsoft/resnet-50")
+
+    # Compile the model using Forge
+    compiled_model = forge.compile(framework_model, batch_input)
+
+    output = compiled_model(batch_input)
+    # Data postprocessing
+    predicted_value = output[0].argmax(-1)
+    predicted_label = [model.config.id2label[pred.item()] for pred in predicted_value]
+
+    for sample in range(batch_size):
+        print(f"True Label: {label[sample]} | Predicted Label: {predicted_label[sample]}")
+
+
+if __name__ == "__main__":
+    run_resnet_pytorch()

--- a/demos/tt-forge-fe/cnn/vilt_demo.py
+++ b/demos/tt-forge-fe/cnn/vilt_demo.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 import requests
 from PIL import Image

--- a/demos/tt-forge-fe/cnn/vilt_demo.py
+++ b/demos/tt-forge-fe/cnn/vilt_demo.py
@@ -1,0 +1,86 @@
+import torch
+import requests
+from PIL import Image
+from transformers import ViltProcessor, ViltForQuestionAnswering
+
+def load_image_from_url(url):
+    """Load an image from a URL."""
+    return Image.open(requests.get(url, stream=True).raw).convert('RGB')
+
+def run_vilt_inference(image_url, question, model_name="dandelin/vilt-b32-finetuned-vqa"):
+    """Run VQA inference using ViLT model.
+    
+    Args:
+        image_url (str): URL of the input image
+        question (str): Question about the image
+        model_name (str): Name of the ViLT model variant
+        
+    Returns:
+        dict: Prediction result with answer and confidence
+    """
+    # Load model and processor
+    processor = ViltProcessor.from_pretrained(model_name)
+    model = ViltForQuestionAnswering.from_pretrained(model_name)
+    model.eval()
+    
+    # Load and process image
+    image = load_image_from_url(image_url)
+    
+    # Prepare inputs
+    inputs = processor(
+        image,
+        question,
+        return_tensors="pt",
+        truncation=True,
+        max_length=512
+    )
+    
+    # Run inference
+    with torch.no_grad():
+        outputs = model(**inputs)
+        logits = outputs.logits
+        
+        # Get probabilities
+        probs = torch.nn.functional.softmax(logits, dim=1)
+        
+        # Get top prediction
+        confidence, idx = torch.max(probs, dim=1)
+        confidence = confidence.item()
+        
+        # Get predicted answer
+        predicted_answer = model.config.id2label[idx.item()]
+    
+    return {
+        'answer': predicted_answer,
+        'confidence': confidence,
+        'question': question
+    }
+
+if __name__ == "__main__":
+    # Example usage
+    test_cases = [
+        {
+            'image_url': "http://images.cocodataset.org/val2017/000000039769.jpg",
+            'question': "What animal is in this image?"
+        },
+        {
+            'image_url': "http://images.cocodataset.org/val2017/000000039769.jpg",
+            'question': "What color is the cat?"
+        },
+        {
+            'image_url': "https://raw.githubusercontent.com/pytorch/hub/master/images/dog.jpg",
+            'question': "Is the dog sitting or standing?"
+        }
+    ]
+    
+    for test_case in test_cases:
+        print(f"\nQuestion: {test_case['question']}")
+        print(f"Image: {test_case['image_url']}")
+        
+        result = run_vilt_inference(
+            image_url=test_case['image_url'],
+            question=test_case['question']
+        )
+        
+        print(f"Answer: {result['answer']}")
+        print(f"Confidence: {result['confidence']:.3f}")

--- a/demos/tt-forge-fe/nlp/bert_demo.py
+++ b/demos/tt-forge-fe/nlp/bert_demo.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 from transformers import BertForSequenceClassification, BertTokenizer
 import forge

--- a/demos/tt-forge-fe/nlp/bert_demo.py
+++ b/demos/tt-forge-fe/nlp/bert_demo.py
@@ -1,0 +1,73 @@
+import torch
+from transformers import BertForSequenceClassification, BertTokenizer
+import forge
+
+def run_bert_classification(text, model_name="textattack/bert-base-uncased-SST-2"):
+    """Run sentiment classification with BERT on SST-2 dataset.
+    
+    Args:
+        text (str): Input text to classify
+        model_name (str): Name of the BERT model variant
+        
+    Returns:
+        dict: Classification result with sentiment label and confidence
+    """
+    # Load model and tokenizer
+    tokenizer = BertTokenizer.from_pretrained(model_name)
+    model = BertForSequenceClassification.from_pretrained(model_name)
+    
+    # Tokenize input
+    inputs = tokenizer(
+        text,
+        max_length=128,
+        padding="max_length",
+        truncation=True,
+        return_tensors="pt"
+    )
+    
+    # Extract tensors from tokenizer output
+    input_ids = inputs['input_ids']
+    attention_mask = inputs['attention_mask']
+    token_type_ids = inputs.get('token_type_ids', None)
+    
+    # Create input sample for compilation
+    if token_type_ids is not None:
+        input_sample = [input_ids, attention_mask, token_type_ids]
+    else:
+        input_sample = [input_ids, attention_mask]
+    
+    # Compile model with forge
+    compiled_model = forge.compile(model, input_sample)
+    
+    # Run inference
+    with torch.no_grad():
+        if token_type_ids is not None:
+            outputs = compiled_model(input_ids, attention_mask, token_type_ids)
+        else:
+            outputs = compiled_model(input_ids, attention_mask)
+        logits = outputs[0]
+        probabilities = torch.nn.functional.softmax(logits, dim=-1)
+    
+    # Get prediction
+    predicted_value = logits[0].argmax(-1).item()
+    confidence = probabilities[0][predicted_value].item()
+    predicted_sentiment = model.config.id2label[predicted_value]
+    
+    return {
+        'text': text,
+        'sentiment': predicted_sentiment,
+        'confidence': confidence
+    }
+
+if __name__ == "__main__":
+    # Example usage - Sentiment Classification
+    reviews = [
+        "This movie was fantastic! I really enjoyed every moment.",
+        "The plot was confusing and the acting was terrible.",
+        "An absolute masterpiece of modern cinema!"
+    ]
+    
+    for review in reviews:
+        result = run_bert_classification(review)
+        print(f"Review: {result['text']}")
+        print(f"Sentiment: {result['sentiment']} (confidence: {result['confidence']:.3f})\n")


### PR DESCRIPTION
Refactoring from `tt-buda-demos` to test out Forge FE.
https://github.com/tenstorrent/tt-buda-demos/blob/main/model_demos/cv_demos/resnet/pytorch_resnet.py 
I had to make some minor changes but overall the demo works.

Please comment on how we should set this up structurally with the folders etc.

@milank94 Let me know your thoughts please. 

