### PR TITLE
Workflow conclusion can be reflected through job conclusion

### DIFF
--- a/.github/actions/uplift-artifacts/action.yml
+++ b/.github/actions/uplift-artifacts/action.yml
@@ -27,6 +27,11 @@ inputs:
     type: bool
     default: false
     required: false
+  workflow_result_in_job:
+    description: "Set that workflow result is job result"
+    type: string
+    default: ""
+    required: false
 
 outputs:
   download-path:
@@ -52,7 +57,7 @@ runs:
       run: |
         loop_count=20
         echo "Search the lastest $loop_count workflow runs to find artifact candidate"
-        runs=$(gh run list -R ${{ inputs.repo }} -w '${{ inputs.workflow }}' -L $loop_count --json status,databaseId,conclusion,url,headBranch,headSha)
+        runs=$(gh run list -R "${{ inputs.repo }}" -b "${{ inputs.branch }}" -w '${{ inputs.workflow }}' -L $loop_count --json status,databaseId,conclusion,url,headBranch,headSha)
 
         array_ptr=0
         success=false
@@ -60,15 +65,15 @@ runs:
         while [[ $array_ptr -ne $loop_count ]]; do
           run_status=$(echo $runs | jq -r --arg array_ptr $array_ptr '.[$array_ptr|tonumber].status')
           run_id=$(echo $runs | jq -r --arg array_ptr $array_ptr '.[$array_ptr|tonumber].databaseId')
-          run_conclusion=$(echo $runs | jq -r --arg array_ptr $array_ptr '.[$array_ptr|tonumber].conclusion')
           run_url=$(echo $runs | jq -r --arg array_ptr $array_ptr '.[$array_ptr|tonumber].url')
           run_branch=$(echo $runs | jq -r --arg array_ptr $array_ptr '.[$array_ptr|tonumber].headBranch')
           run_commit_sha=$(echo $runs | jq -r --arg array_ptr $array_ptr '.[$array_ptr|tonumber].headSha')
+          databaseId=$(echo $runs | jq -r --arg array_ptr $array_ptr '.[$array_ptr|tonumber].databaseId')
 
-          if [[ "$run_branch" != "${{ inputs.branch }}" ]]; then
-              echo "Skipping Workflow Run: $run_url due to branch not being ${{ inputs.branch }}"
-              array_ptr=$((array_ptr+1))
-              continue
+          if [[ -n "${{ inputs.workflow_result_in_job }}" ]]; then
+            run_conclusion=$(gh run view -R "${{ inputs.repo }}" $databaseId --json workflowName,conclusion,jobs | jq -r '.jobs[] | select(.name == "${{ inputs.workflow_result_in_job }}") | .conclusion')
+          else
+            run_conclusion=$(echo $runs | jq -r --arg array_ptr $array_ptr '.[$array_ptr|tonumber].conclusion')
           fi
 
           if [[ "$run_status" == "completed" ]]; then

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -28,15 +28,18 @@ jobs:
       id: tt-forge-fe-artifacts
       with:
         repo: tenstorrent/tt-forge-fe
+        branch: "main"
         workflow: On nightly
         artifact_download_glob: '*{wheel,reports}*'
         artifact_cleanup_glob: '*.json'
         workflow_allow_failed: true
+        workflow_result_in_job: "fail-notify"
     - name: Uplift tenstorrent/tt-torch nightly artifacts
       uses: ./.github/actions/uplift-artifacts
       id: tt-torch-artifacts
       with:
         repo: tenstorrent/tt-torch
+        branch: "main"
         workflow: Nightly Tests
         artifact_download_glob: '*{install-artifacts,test-reports-models-}*'
         artifact_cleanup_glob: 'torchvision*'


### PR DESCRIPTION
New refurbished nightly run for tt-forge-fe runs all available tests including those known to fail.
However, the release is not dependent on these tests, even if failed we claim that build is successful.
One of the most requested features on GitHub is "allow-failure" but still it is not available.
So, there is fail-notify job that summarize nightly run and decide whether it is successful or failed (and send notification on slack if failed). Result of this job should be used as success mark for release instead of whole workflow result.