### PR TITLE
Download artifact upgrade

### DIFF
--- a/.github/actions/download-artifact/action.yaml
+++ b/.github/actions/download-artifact/action.yaml
@@ -55,7 +55,7 @@ runs:
         fi
 
         # Check if download path is not malicious
-        if [[ "$path" != "${GITHUB_WORKSPACE}"* || "$path" == "${GITHUB_WORKSPACE}" ]]; then
+        if [[ "$path" != "${GITHUB_WORKSPACE}"* ]]; then
           echo "Error: Download path must be within ${GITHUB_WORKSPACE} but not ${GITHUB_WORKSPACE} itself."
           exit 1
         fi

--- a/.github/actions/download-artifact/action.yaml
+++ b/.github/actions/download-artifact/action.yaml
@@ -1,7 +1,7 @@
 name: Download Artifact
 
 description: |
-  Download an artifact from a GitHub workflow run and extract it to a specified (relative) path.
+  Download an artifact from a GitHub workflow run and extract it to a specified path.
   Automatically untars tar files. If download fails, it retries the specified number of times with a wait time in between.
 
 inputs:
@@ -9,8 +9,8 @@ inputs:
     description: 'Name of the artifact to download'
     required: true
   path:
-    description: 'Relative path where to download the artifact'
-    required: true
+    description: 'Path where to download the artifact (must be within the workspace)'
+    required: false
   repository:
     description: 'Repository from which to download the artifact (format: owner/repo)'
     required: false
@@ -47,15 +47,24 @@ runs:
       run: |
         set -e
 
-        path=$(realpath "${GITHUB_WORKSPACE}/${DOWNLOAD_PATH}")
+        if [ -z "${DOWNLOAD_PATH}" ]; then
+          path="${GITHUB_WORKSPACE}"
+        else
+          path=$(realpath "${DOWNLOAD_PATH}")
+        fi
+
         # Check if download path is not malicious
         if [[ "$path" != "${GITHUB_WORKSPACE}"* || "$path" == "${GITHUB_WORKSPACE}" ]]; then
           echo "Error: Download path must be within ${GITHUB_WORKSPACE} but not ${GITHUB_WORKSPACE} itself."
           exit 1
         fi
+
         # Make sure download dir is empty and exists
-        rm -rf "$path"
-        mkdir -p "$path"
+        if [[ "$path" != "${GITHUB_WORKSPACE}" ]]; then
+          echo "Removeing existing directory: $path"
+          rm -rf "$path"
+          mkdir -p "$path"
+        fi
 
         # Function to download artifact
         download_artifact() {

--- a/.github/actions/download-artifact/action.yaml
+++ b/.github/actions/download-artifact/action.yaml
@@ -29,7 +29,8 @@ inputs:
     default: '10'
   github_token:
     description: 'GitHub token used for authentication'
-    required: true
+    required: false
+    default: ${{ secrets.GITHUB_TOKEN }}
 
 runs:
   using: 'composite'

--- a/.github/actions/download-artifact/action.yaml
+++ b/.github/actions/download-artifact/action.yaml
@@ -30,7 +30,7 @@ inputs:
   github_token:
     description: 'GitHub token used for authentication'
     required: false
-    default: ${{ secrets.GITHUB_TOKEN }}
+    default: ${{ github.token }}
 
 runs:
   using: 'composite'

--- a/.github/actions/download-artifact/action.yaml
+++ b/.github/actions/download-artifact/action.yaml
@@ -62,7 +62,7 @@ runs:
 
         # Make sure download dir is empty and exists
         if [[ "$path" != "${GITHUB_WORKSPACE}" ]]; then
-          echo "Removeing existing directory: $path"
+          echo "Removing existing directory: $path"
           rm -rf "$path"
           mkdir -p "$path"
         fi

--- a/.github/workflows/download-artifact-test.yml
+++ b/.github/workflows/download-artifact-test.yml
@@ -37,7 +37,7 @@ jobs:
           path: test-file.txt
 
       - name: Download single file
-        uses: ./github/actions/download-artifact
+        uses: ./.github/actions/download-artifact
         with:
           name: single-file
           path: downloaded-single-file
@@ -55,7 +55,7 @@ jobs:
           path: test-directory/
 
       - name: Download directory
-        uses: ./github/actions/download-artifact
+        uses: ./.github/actions/download-artifact
         with:
           name: directory
           path: downloaded-directory
@@ -73,7 +73,7 @@ jobs:
           path: test-archive.tar.gz
 
       - name: Download tar archive
-        uses: ./github/actions/download-artifact
+        uses: ./.github/actions/download-artifact
         with:
           name: archive
           path: downloaded-archive
@@ -86,7 +86,7 @@ jobs:
       # Test 4: Attempt to download to restricted filesystem location
       - name: Try download to restricted path
         id: restricted-path
-        uses: ./github/actions/download-artifact
+        uses: ./.github/actions/download-artifact
         continue-on-error: true
         with:
           name: single-file

--- a/.github/workflows/download-artifact-test.yml
+++ b/.github/workflows/download-artifact-test.yml
@@ -3,7 +3,7 @@ name: Download Artifact Test
 on:
   pull_request:
     paths:
-      - '.github/artifacts/download-artifact**/**'
+      - '.github/actions/download-artifact**'
 
 jobs:
   test-artifact-methods:

--- a/.github/workflows/download-artifact-test.yml
+++ b/.github/workflows/download-artifact-test.yml
@@ -100,3 +100,17 @@ jobs:
             echo "❌ Restricted path test failed - Action should have failed"
             exit 1
           fi
+
+      # Test 5: Download a single file without specifying a path
+      - name: Save uploaded single file
+        run: mv test-file.txt test-file-orig.txt
+
+      - name: Download single file
+        uses: ./.github/actions/download-artifact
+        with:
+          name: single-file
+
+      - name: Verify single file
+        run: |
+          diff test-file-orig.txt test-file.txt
+          if [ $? -eq 0 ]; then echo "✅ Single file download without path test passed"; else echo "❌ Single file download without path test failed"; exit 1; fi

--- a/.github/workflows/download-artifact-test.yml
+++ b/.github/workflows/download-artifact-test.yml
@@ -1,0 +1,102 @@
+name: Download Artifact Test
+
+on:
+  pull_request:
+    paths:
+      - '.github/artifacts/download-artifact**/**'
+
+jobs:
+  test-artifact-methods:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Create test files
+      - name: Create test content
+        run: |
+          # Create a single file
+          echo "Test content for single file" > test-file.txt
+
+          # Create a directory with multiple files
+          mkdir -p test-directory
+          echo "File 1 content" > test-directory/file1.txt
+          echo "File 2 content" > test-directory/file2.txt
+
+          # Create a tar archive
+          mkdir -p tar-content
+          echo "Tar file 1" > tar-content/file1.txt
+          echo "Tar file 2" > tar-content/file2.txt
+          tar -czf test-archive.tar.gz tar-content/
+
+      # Test 1: Upload and download a single file
+      - name: Upload single file
+        uses: actions/upload-artifact@v4
+        with:
+          name: single-file
+          path: test-file.txt
+
+      - name: Download single file
+        uses: ./github/actions/download-artifact
+        with:
+          name: single-file
+          path: downloaded-single-file
+
+      - name: Verify single file
+        run: |
+          diff test-file.txt downloaded-single-file/test-file.txt
+          if [ $? -eq 0 ]; then echo "✅ Single file test passed"; else echo "❌ Single file test failed"; exit 1; fi
+
+      # Test 2: Upload and download a directory
+      - name: Upload directory
+        uses: actions/upload-artifact@v4
+        with:
+          name: directory
+          path: test-directory/
+
+      - name: Download directory
+        uses: ./github/actions/download-artifact
+        with:
+          name: directory
+          path: downloaded-directory
+
+      - name: Verify directory
+        run: |
+          diff -r test-directory/ downloaded-directory/
+          if [ $? -eq 0 ]; then echo "✅ Directory test passed"; else echo "❌ Directory test failed"; exit 1; fi
+
+      # Test 3: Upload and download a tar archive
+      - name: Upload tar archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: archive
+          path: test-archive.tar.gz
+
+      - name: Download tar archive
+        uses: ./github/actions/download-artifact
+        with:
+          name: archive
+          path: downloaded-archive
+
+      - name: Verify tar archive
+        run: |
+          diff -r tar-content/ downloaded-archive/
+          if [ $? -eq 0 ]; then echo "✅ Archive test passed"; else echo "❌ Archive test failed"; exit 1; fi
+
+      # Test 4: Attempt to download to restricted filesystem location
+      - name: Try download to restricted path
+        id: restricted-path
+        uses: ./github/actions/download-artifact
+        continue-on-error: true
+        with:
+          name: single-file
+          path: /tmp/restricted
+
+      - name: Verify restricted path fails
+        run: |
+          if [ "${{ steps.restricted-path.outcome }}" == "failure" ]; then
+            echo "✅ Restricted path test passed - Action failed as expected"
+          else
+            echo "❌ Restricted path test failed - Action should have failed"
+            exit 1
+          fi

--- a/.github/workflows/download-artifact-test.yml
+++ b/.github/workflows/download-artifact-test.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Verify tar archive
         run: |
-          diff -r tar-content/ downloaded-archive/
+          diff -r tar-content/ downloaded-archive/tar-content/
           if [ $? -eq 0 ]; then echo "✅ Archive test passed"; else echo "❌ Archive test failed"; exit 1; fi
 
       # Test 4: Attempt to download to restricted filesystem location


### PR DESCRIPTION
Download-artifact action can use absolute path (has to be within workspace dir) or workspace dir. Input parameter "path" is not required (it will use workspace dir by default).
Added download-artifact test.