### PR TITLE
Fix workflow permissions issue

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -10,6 +10,10 @@ on:
         default: true
         description: Put PR in draft mode for testing
 
+permissions:
+  pages: write
+  id-token: write
+  contents: write
 
 jobs:
   nightly-release:


### PR DESCRIPTION
### Problem
The `Nightly release` workflow is failing as it doesn't have sufficient permissions.

### Cause
Switch to the Github Enterprise forces us to define the CI permissions explicitly.

### Solution
Defined the permissions for the `Nightly release` workflow specifically.