### PR TITLE
Disable nightly model table 

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -100,9 +100,9 @@ jobs:
         repo: tt-mlir
         artifact_job_json: "${{ toJSON(steps.tt-mlir-artifacts.outputs) }}"
         release_type: 'nightly'
-    - name: cat readme
-      run: |
-        cat ${{ github.workspace }}/release/docs/readme_hardware_table.md >> ${{ github.workspace }}/release/docs/readme
+    #- name: cat readme
+    #  run: |
+    #    cat ${{ github.workspace }}/release/docs/readme_hardware_table.md >> ${{ github.workspace }}/release/docs/readme
     - name: Release
       uses: softprops/action-gh-release@v2
       with:


### PR DESCRIPTION
Temporarily disabling model table due to doc size limit. This will be re-add once the releaser is refactored in the upcoming stable/rc releaser

Error
```bash
⚠️ Unexpected error fetching GitHub release for tag refs/heads/main: HttpError: Validation Failed: {"resource":"Release","code":"custom","field":"body","message":"body is too long (maximum is 125000 characters)"} 
```

https://github.com/tenstorrent/tt-forge/actions/runs/15247384467/job/42876422239#step:13:19