### PR TITLE
Fix skip publish went release tag already exist

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -49,6 +49,7 @@ jobs:
     outputs:
       release-artifacts-id: ${{ steps.build-release.outputs.release-artifacts-id }}
       run-conclusion: ${{ steps.build-release.outputs.run-conclusion }}
+      check-tag: ${{ steps.check-tag.outputs.exists }}
     runs-on: ubuntu-latest
     needs: get-version
     env:
@@ -94,6 +95,7 @@ jobs:
           release-artifacts-id: ${{ needs.build-release.outputs.release-artifacts-id }}
 
   publish-release:
+    if: ${{ needs.build-release.outputs.check-tag == 'false' }}
     needs:
       - build-release
       - get-version


### PR DESCRIPTION
Fixes issue where publish would still run even though the release build step was skipped.

<img width="1393" alt="image" src="https://github.com/user-attachments/assets/719d4a61-5a3f-462b-8373-04c987ca220e" />



https://github.com/tenstorrent/tt-forge/actions/runs/15434876149/job/43439237135#step:3:10

Working test.
https://github.com/tenstorrent/tt-forge/actions/runs/15448513068/job/43484508903#step:3:10