### PR TITLE
Docker Builder workflow

### DIFF
--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -1,0 +1,63 @@
+name: Build Docker
+description: Build Docker
+
+inputs:
+  docker_build_json:
+    required: false
+    type: string
+  image_name:
+    required: false
+    type: string
+  dockerfile:
+    required: false
+    type: string
+  tag:
+    required: false
+    type: string
+  from_image:
+    required: false
+    type: string
+  skip_push:
+    required: false
+    type: boolean
+    default: false
+  force_build:
+    required: false
+    type: boolean
+    default: false
+
+runs:
+  using: "composite"
+  steps:
+    - name: Build docker image
+      id: build-docker
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        export SKIP_PUSH="${{ inputs.skip_push }}"
+        export FORCE_BUILD="${{ inputs.force_build }}"
+
+        # Used for single image build
+        if [ -z "${{ inputs.docker_build_json }}" ]; then
+          export IMAGE_NAME="${{ inputs.image_name }}"
+          export DOCKER_TAG="${{ inputs.tag }}"
+          export DOCKERFILE="${{ inputs.dockerfile }}"
+          export FROM_IMAGE="${{ inputs.from_image }}"
+          ./.github/scripts/build-docker.sh
+          #TODO: Return json of created image for ci
+
+        else
+          # Used to build multiple images on same host for improved cache hits
+          while read dict
+          do
+            export IMAGE_NAME=$(echo "$dict" | jq -r .image_name)
+            export DOCKER_TAG=$(echo "$dict" | jq -r .tag)
+            export DOCKERFILE=$(echo "$dict" | jq -r .dockerfile)
+            export FROM_IMAGE=$(echo "$dict" | jq -r .from_image || "")
+            ./.github/scripts/build-docker.sh
+
+            #TODO: Return json of created images for ci
+
+          done < <(echo '${{ inputs.docker_build_json }}' | jq -c '.[]')
+        fi

--- a/.github/actions/set-docker-facts/action.yaml
+++ b/.github/actions/set-docker-facts/action.yaml
@@ -1,0 +1,40 @@
+
+name: "Set Docker Facts"
+description: "Set Docker Facts"
+inputs:
+  dockerfile:
+    description: "Dockerfile name"
+    required: true
+outputs:
+  image_name:
+    description: "Image name"
+    value: ${{ steps.set-docker-facts.outputs.image_name }}
+  tag:
+    description: "Tag"
+    value: ${{ steps.set-docker-facts.outputs.tag }}
+  from_image:
+    description: "From image"
+    value: ${{ steps.set-docker-facts.outputs.from_image }}
+runs:
+  using: "composite"
+  steps:
+    - name: Set Docker facts
+      id: set-docker-facts
+      shell: bash
+      run: |
+        # Set docker facts based on repo
+        registry="ghcr.io/${{ github.repository }}"
+        dockerfile_suffix=$( echo "${{ inputs.dockerfile }}" | grep -oP '(?<=Dockerfile\.).*')
+        image_name="${registry}/${dockerfile_suffix}"
+        from_image=""
+
+        tag="$(sha256sum ${{ inputs.dockerfile }} | sha256sum | cut -d ' ' -f 1)"
+
+        echo "Using image name: $image_name"
+        echo "Using tag: $tag"
+        echo "Using from_image: $from_image"
+
+        # Set outputs
+        echo "image_name=$image_name" >> $GITHUB_OUTPUT
+        echo "tag=$tag" >> $GITHUB_OUTPUT
+        echo "from_image=$from_image" >> $GITHUB_OUTPUT

--- a/.github/dockerfiles/Dockerfile.base
+++ b/.github/dockerfiles/Dockerfile.base
@@ -1,0 +1,71 @@
+FROM ubuntu:22.04
+SHELL ["/bin/bash", "-c"]
+
+# Set environment variables
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install dependencies
+RUN apt-get update && apt-get install -y \
+    software-properties-common \
+    build-essential \
+    python3-dev \
+    python3-venv \
+    python3-pip \
+    git \
+    libhwloc-dev \
+    pandoc \
+    libtbb-dev \
+    libcapstone-dev \
+    pkg-config \
+    linux-tools-generic \
+    ninja-build \
+    wget \
+    libgtest-dev \
+    cmake \
+    ccache \
+    doxygen \
+    graphviz \
+    patchelf \
+    libyaml-cpp-dev \
+    libboost-all-dev \
+    curl \
+    jq \
+    sudo \
+    gh \
+    lcov \
+    unzip
+
+# Install clang 17
+RUN wget https://apt.llvm.org/llvm.sh && \
+    chmod u+x llvm.sh && \
+    ./llvm.sh 17 && \
+    apt install -y libc++-17-dev libc++abi-17-dev && \
+    ln -s /usr/bin/clang-17 /usr/bin/clang && \
+    ln -s /usr/bin/clang++-17 /usr/bin/clang++ && \
+    ln -s /usr/bin/clangd-17 /usr/bin/clangd
+
+# Install python packages
+RUN pip install cmake
+
+# Install Googletest
+RUN git clone https://github.com/google/googletest.git -b release-1.12.1 && \
+    cd googletest && \
+    mkdir build && \
+    cd build && \
+    cmake .. -DBUILD_GMOCK=OFF && \
+    make && \
+    make install && \
+    cd ../.. && \
+    rm -rf googletest
+
+# Install mpi-ulfm from the tenstorrent repository
+RUN set -eux; \
+    apt-get update && \
+    apt-get install -y -f \
+        wget ca-certificates && \
+    TMP_DIR="$(mktemp -d)" && \
+    DEB_URL="https://github.com/dmakoviichuk-tt/mpi-ulfm/releases/download/v5.0.7-ulfm/openmpi-ulfm_5.0.7-1_amd64.deb" && \
+    wget -qO "$TMP_DIR/ompi.deb" "$DEB_URL" && \
+    apt-get install -f -y "$TMP_DIR/ompi.deb" && \
+    rm -rf "$TMP_DIR" && \
+    rm -rf /var/lib/apt/lists/*

--- a/.github/dockerfiles/Dockerfile.manylinux_2_34_x86_64
+++ b/.github/dockerfiles/Dockerfile.manylinux_2_34_x86_64
@@ -1,0 +1,32 @@
+FROM quay.io/pypa/manylinux_2_34_x86_64
+SHELL ["/bin/bash", "-c"]
+
+# Force dnf to stop being mean
+RUN FILES=(/etc/yum.repos.d/almalinux*.repo) && \
+    sed --in-place -e 's/^mirrorlist=/# mirrorlist=/g' -e "s/^# baseurl=/baseurl=/" "${FILES[@]}"
+
+# Install dependencies
+RUN dnf check-update || true
+RUN dnf install --refresh -y epel-release
+RUN dnf config-manager --set-enabled crb
+
+RUN dnf install --refresh -y \
+    gcc-c++ make cmake ninja-build pkgconf-pkg-config ccache \
+    clang lld \
+    git wget curl jq sudo patch unzip \
+    hwloc-devel tbb-devel capstone-devel \
+    yaml-cpp-devel boost-devel libcurl-devel \
+    pandoc doxygen graphviz patchelf lcov perf \
+    xz
+
+RUN dnf clean all
+
+# Install Ninja
+ENV NINJA_VERSION="1.11.1"
+ENV NINJA_URL="https://github.com/ninja-build/ninja/releases/download/v${NINJA_VERSION}/ninja-linux.zip"
+ENV NINJA_ZIP="ninja-linux.zip"
+
+RUN curl -L -o "${NINJA_ZIP}" "${NINJA_URL}"
+RUN unzip "${NINJA_ZIP}" -d /usr/local/bin/
+RUN chmod +x /usr/local/bin/ninja
+RUN rm -f "${NINJA_ZIP}"

--- a/.github/scripts/build-docker.sh
+++ b/.github/scripts/build-docker.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+# Are we on main branch
+ON_MAIN=$(git branch --show-current | grep -q main && echo "true" || echo "false")
+
+build() {
+
+    echo "Building image $IMAGE_NAME:$DOCKER_TAG"
+    docker build \
+        --progress=plain \
+        --build-arg FROM_TAG=$DOCKER_TAG \
+        ${FROM_IMAGE:+--build-arg FROM_IMAGE=$FROM_IMAGE} \
+        -t $IMAGE_NAME:$DOCKER_TAG \
+        -t $IMAGE_NAME:latest \
+        -f $DOCKERFILE .
+
+}
+
+build_and_push() {
+
+    if [ "$FORCE_BUILD" = "true" ]; then
+        build $IMAGE_NAME $DOCKERFILE $FROM_IMAGE
+    else
+        # Check if image already exists
+        set +e
+        if docker manifest inspect $IMAGE_NAME:$DOCKER_TAG > /dev/null; then
+            set -e
+            echo "Image $IMAGE_NAME:$DOCKER_TAG already exists"
+            SKIP_PUSH="true"
+        else
+            build $IMAGE_NAME $DOCKERFILE $FROM_IMAGE
+        fi
+    fi
+
+    # Push image
+    if [ "$SKIP_PUSH" = "false" ]; then
+        echo "Pushing image $IMAGE_NAME:$DOCKER_TAG"
+        docker push $IMAGE_NAME:$DOCKER_TAG
+    fi
+
+    # If we are on main branch we always push latest tag even if image already exists or "$SKIP_PUSH" = "true"
+    if [ "$ON_MAIN" = "true" ]; then
+        printf "\nPushing latest tag for $IMAGE_NAME"
+        # Used to push both tags in one command on the original sha256 sum layer remotely (docker create manifest create a new sha256 sum only with only with new tag)
+        docker buildx imagetools create $IMAGE_NAME:$DOCKER_TAG --tag $IMAGE_NAME:latest --tag $IMAGE_NAME:$DOCKER_TAG
+    fi
+}
+
+build_and_push $IMAGE_NAME $DOCKERFILE $FROM_IMAGE

--- a/.github/workflows/test-update-docker-images.yml
+++ b/.github/workflows/test-update-docker-images.yml
@@ -1,0 +1,70 @@
+name: Test Docker Update images
+
+on:
+    pull_request:
+      types: [opened, synchronize, reopened, ready_for_review]
+      branches: [ "main" ]
+      paths:
+        - '.github/actions/build-docker/**'
+        - '.github/actions/set-docker-facts/**'
+        - '.github/scripts/build-docker.sh'
+        - '.github/workflows/test-update-docker-images.yml'
+        - '.github/workflows/update-docker-images.yml'
+
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
+
+jobs:
+  test-single-host-single-docker-update-image:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fix permissions
+        shell: bash
+        run: sudo chown ubuntu:ubuntu -R $(pwd) || true
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build Docker Images
+        id: build-docker
+        uses: ./.github/actions/build-docker
+        with:
+          image_name: test
+          dockerfile: .github/dockerfiles/Dockerfile.manylinux_2_34_x86_64
+          tag: test
+          from_image: "ghcr.io/${{ github.repository }}/manylinux_2_34_x86_64:latest"
+          skip_push: true
+          force_build: true
+
+  test-single-host-multiple-docker-update-images:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fix permissions
+        shell: bash
+        run: sudo chown ubuntu:ubuntu -R $(pwd) || true
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: set json payload
+        id: set-json-payload
+        shell: bash
+        run: |
+          json_results='[{"dockerfile": ".github/dockerfiles/Dockerfile.manylinux_2_34_x86_64", "tag": "test1", "image_name": "test1"},{"dockerfile": ".github/dockerfiles/Dockerfile.manylinux_2_34_x86_64", "tag": "test2", "image_name": "test2"}]'
+          echo "json_results=$json_results" >> $GITHUB_OUTPUT
+
+      - name: Build Docker Images
+        id: build-docker
+        uses: ./.github/actions/build-docker
+        with:
+          docker_build_json: ${{ steps.set-json-payload.outputs.json_results }}
+          skip_push: true
+          force_build: true

--- a/.github/workflows/update-docker-images.yml
+++ b/.github/workflows/update-docker-images.yml
@@ -1,0 +1,101 @@
+name: Update Docker images
+
+on:
+    push:
+      branches:
+        - main
+      paths:
+        - '.github/dockerfiles/**'
+    pull_request:
+      types: [opened, synchronize, reopened, ready_for_review]
+      branches: [ "main" ]
+      paths:
+        - '.github/dockerfiles/**'
+    workflow_call:
+      inputs:
+        skip_push:
+          type: boolean
+          default: false
+        force_build:
+          type: boolean
+          default: false
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
+
+jobs:
+  changed-docker-files:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    outputs:
+      files: ${{ steps.changed-files.outputs.all_changed_files }}
+      docker_build_json: ${{ steps.docker_job_json.outputs.json_results }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Ignore files
+        id: changed-files
+        uses: tj-actions/changed-files@v46
+        with:
+          files: |
+            .github/dockerfiles/**
+      - name: create json for dockerbuild job
+        shell: bash
+        id: docker_job_json
+        run: |
+          json_results="[]"
+          changed_docker_files="${{ steps.changed-files.outputs.all_changed_files }}"
+          echo "changed_docker_files: $changed_docker_files"
+          for dockerfile in $changed_docker_files; do
+            json_results=$(echo $json_results | jq -r -c --arg dockerfile "$dockerfile" '. += [{
+                "dockerfile": $dockerfile,
+            }]')
+          done
+
+          echo "json_results=$json_results"
+          echo "json_results=$json_results" >> $GITHUB_OUTPUT
+
+  build-docker-images:
+    needs: changed-docker-files
+    if: ${{ needs.changed-docker-files.outputs.files }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.changed-docker-files.outputs.docker_build_json) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fix permissions
+        shell: bash
+        run: sudo chown ubuntu:ubuntu -R $(pwd) || true
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set Docker facts
+        id: set-docker-facts
+        uses: ./.github/actions/set-docker-facts
+        with:
+          dockerfile: ${{ matrix.dockerfile }}
+
+      - name: Build Docker Images
+        id: build-docker
+        uses: ./.github/actions/build-docker
+        with:
+          image_name: ${{ steps.set-docker-facts.outputs.image_name }}
+          dockerfile: ${{ matrix.dockerfile }}
+          tag: ${{ steps.set-docker-facts.outputs.tag }}
+          from_image: ${{ steps.set-docker-facts.outputs.from_image }}
+          skip_push: ${{ inputs.skip_push  || false }}
+          force_build: ${{ inputs.force_build || false }}


### PR DESCRIPTION
This adds the docker image builder workflow with testing.

Images that are being created are:
- base (sourced from https://github.com/tenstorrent/tt-mlir/blob/main/.github/Dockerfile.base)
- manylinux_2_34_x86_64 (sourced from https://github.com/tenstorrent/tt-mlir/blob/main/.github/Dockerfile.cibuildwheel)

The short-term intent here is to share these images across our frontends. In the long term, we can share this docker build action across our other forge projects.

Once approved, I will switch over the bases in tt-mlir and add these images to the CIv2 preseed cache to improve build times.
https://github.com/tenstorrent/github-ci-infra/blob/main/image_builder/scripts/metal_caches.sh#L16

 