### PR TITLE
Use install-artifacts-release from tt-torch

### DIFF
--- a/.github/actions/set-release-facts/action.yaml
+++ b/.github/actions/set-release-facts/action.yaml
@@ -61,7 +61,7 @@ runs:
             if [[ "${{ inputs.release_type }}" == "nightly" ]]; then
                 workflow="On push"
             fi
-            artifact_download_glob='*{install-artifacts,test-reports-models-}*'
+            artifact_download_glob='*{install-artifacts-release,test-reports-models-}*'
             artifact_cleanup_file_glob='*torchvision*'
             artifact_cleanup_folder_glob='*install-artifacts-debug*'
             pip_wheel_names="tt-torch"


### PR DESCRIPTION
tt-torch will start publishing an "install-artifacts-release" artifact, without codecov, from its on-push CI. 

This change allows that artifact to be captured instead of the current "install-artifacts" build.