### PR TITLE
 release branch workflow

### DIFF
--- a/.github/actions/create-rc-branch/action.yml
+++ b/.github/actions/create-rc-branch/action.yml
@@ -6,29 +6,21 @@ inputs:
   repo:
     description: "Repo name"
     required: true
-  branch:
-    description: "Branch name"
-    default: "main"
-    required: false
-  workflow:
-    description: "Workflow name"
-    required: true
-  workflow_result_in_job:
-    description: "Set that workflow result is job result"
-    default: ""
-    required: false
-  MAJOR:
-    description: "Major version"
-    required: true
-  MINOR:
-    description: "Minor version"
-    required: true
   draft:
     description: "Draft release"
     required: false
+    default: false
   GH_TOKEN:
     description: "GitHub token"
     required: true
+  commit:
+    description: "Commit sha if you want to override release branch selection by last passing workflow"
+    required: false
+  workflow_allow_failed:
+    description: "Ignore if workflow has failed"
+    required: false
+    type: boolean
+    default: false
 
 outputs:
   branch_name:
@@ -37,68 +29,62 @@ outputs:
   tag_name:
     description: "Tag name"
     value: ${{ steps.create-rc-branch.outputs.tag_name }}
+
 runs:
   using: "composite"
   steps:
+    - name: version tag
+      id: version-tag
+      shell: bash
+      run: |
+        if [ -f .version ]; then
+          source .version
+        else
+          wget https://raw.githubusercontent.com/tenstorrent/tt-forge/refs/heads/main/.version
+          source .version
+        fi
+
+        echo "MAJOR=$MAJOR" >> $GITHUB_OUTPUT
+        echo "MINOR=$MINOR" >> $GITHUB_OUTPUT
+
+    - name: Set Release Facts
+      id: set-release-facts
+      uses: ./.github/actions/set-release-facts
+      with:
+        repo: ${{ inputs.repo }}
+        release_type: 'rc'
+
     - name: Find workflow candidate
       id: find_workflow
       uses: ./.github/actions/find-workflow
+      env:
+        GH_TOKEN: ${{ github.token }}
       with:
         repo: ${{ inputs.repo }}
-        workflow: ${{ inputs.workflow }}
-        workflow_allow_failed: false
-        workflow_result_in_job: ${{ inputs.workflow_result_in_job }}
+        workflow: ${{ inputs.draft == 'true' && 'Daily Releaser' || steps.set-release-facts.outputs.workflow }}
+        workflow_allow_failed: ${{ inputs.workflow_allow_failed }}
+        workflow_result_in_job: ${{ steps.set-release-facts.outputs.workflow_result_in_job }}
+        commit: ${{ inputs.commit }}
 
-
-    - name: Checkout target repo
-      uses: actions/checkout@v4
-      with:
-        repository: ${{ inputs.repo }}
-        token: ${{ env.GH_TOKEN }}
-        ref: ${{ steps.find_workflow.outputs.run-commit-sha }}
-        fetch-depth: 0
-
-
-    - name: Create new branch and push
+    - name: Create new branch and tag
       id: create-rc-branch
       shell: bash
       run: |
         # Get the latest release branch and create a new semver bumped release branch in frontend repos
 
         release_prefix="release"
+        tag_prefix="${{ steps.version-tag.outputs.MAJOR }}.${{ steps.version-tag.outputs.MINOR }}.0"
 
         if [ "${{ inputs.draft }}" == "true" ]; then
-            release_prefix="draft-release"
-            echo "Creating draft release branch"
+            release_prefix="draft-${{ steps.set-release-facts.outputs.repo_short }}-release"
+            tag_prefix="draft-${{ steps.set-release-facts.outputs.repo_short }}-${tag_prefix}"
         fi
 
-        # broken up so release prefix can be variable
-        regex="(?<=origin\\/"
-        regex+="${release_prefix}"
-        regex+="-)\\d+\\.\\d+$"
-
-        echo "regex: $regex"
-
-        latest_release_branch_version=$(git for-each-ref refs/remotes/origin/ --sort=authordate --format='%(refname:short)' | grep -oP "${regex}" | tail -n 1 || echo "Could not find latest release branch")
-        if [ -z "$latest_release_branch_version" ]; then
-            new_release_tag="${{ inputs.MAJOR }}.${{ inputs.MINOR }}"
-            new_release_branch_name="${release_prefix}-${new_release_tag}"
-        else
-            echo "Current Release Branch is $latest_release_branch_version"
-            IFS='.' read -r major minor <<< "$latest_release_branch_version"
-
-            if [ "$major" -eq "${{ inputs.MAJOR }}" ] ; then
-                # Update existing stable branch with minor version
-                new_release_tag="${major}.$((minor+1))"
-                new_release_branch_name="${release_prefix}-${new_release_tag}"
-            else
-                # Create new major release branch
-                new_release_tag="${{ inputs.MAJOR }}.0"
-                new_release_branch_name="${release_prefix}-${new_release_tag}"
-            fi
-        fi
+        new_release_tag="${tag_prefix}rc1"
+        new_release_branch_name="${release_prefix}-${{ steps.version-tag.outputs.MAJOR }}.${{ steps.version-tag.outputs.MINOR }}"
 
         echo "New Release Branch is $new_release_branch_name"
+        echo "New Release Tag is $new_release_tag"
 
         echo "branch_name=$new_release_branch_name" >> $GITHUB_OUTPUT
         echo "tag_name=$new_release_tag" >> $GITHUB_OUTPUT
@@ -106,20 +92,36 @@ runs:
     - uses: mukunku/tag-exists-action@v1.6.0
       id: check-tag
       with:
-        tag: ${{ steps.check-tag.outputs.tag_name }}
+        tag: ${{ steps.create-rc-branch.outputs.tag_name }}
         repo: ${{ inputs.repo }}
+
+    - name: Checkout target repo
+      uses: actions/checkout@v4
+      if: ${{  inputs.draft == 'false' && steps.check-tag.outputs.exists == 'false' }}
+      with:
+        repository: ${{ inputs.repo }}
+        token: ${{ inputs.GH_TOKEN }}
+        ref: ${{ steps.find_workflow.outputs.run-commit-sha }}
+        fetch-depth: 0
 
     - name: Create Release Branch
       if: steps.check-tag.outputs.exists == 'false'
       shell: bash
       run: |
+        # Create the release branch and add the starter tag
+
         new_release_tag="${{ steps.create-rc-branch.outputs.tag_name }}"
         new_release_branch_name="${{ steps.create-rc-branch.outputs.branch_name }}"
 
         git checkout -b $new_release_branch_name
-        git tag "${new_release_tag}.rc.0"
+        git tag "$new_release_tag"
         git push origin $new_release_branch_name --tags
 
+        # Clean up branch and tag if draft for e2e testing
+        if [[ "${{ inputs.draft }}" == "true" ]]; then
+            git push --delete origin $new_release_tag
+            git push -d origin $new_release_branch_name
+        fi
 
     # Recheckout forge repo to fix side effects for clean up job
     - uses: actions/checkout@v4

--- a/.github/workflows/create-version-branches.yml
+++ b/.github/workflows/create-version-branches.yml
@@ -1,94 +1,57 @@
 name: Create Version Branch releaser
 
 on:
-  schedule:
-  - cron: '0 6 24 * *'
   workflow_dispatch:
     inputs:
       draft:
         description: 'Put PR in draft mode for testing'
-        type: string
-        default: 'true'
+        type: boolean
+        default: true
         required: false
-      only_repos:
+      repo:
         type: string
-        description: 'comma separated list of repos to release RC branch for e.g tt-forge-fe,tt-torch'
+        description: 'Repo to release RC branch for e.g tenstorrent/tt-forge-fe'
         required: true
-        default: ''
+      workflow_allow_failed:
+        description: 'Run even if workflow has failed'
+        required: false
+        type: boolean
+        default: false
+      commit:
+        description: "Commit sha if you want to override release branch selection"
+        required: false
+        type: string
   workflow_call:
     inputs:
       draft:
         description: 'Put PR in draft mode for testing'
-        type: string
-        default: 'true'
+        type: boolean
+        default: true
         required: false
-      only_repos:
+      repo:
         type: string
-        description: 'comma separated list of repos to release RC branch for e.g tt-forge-fe,tt-torch'
+        description: 'Repo to release RC branch for e.g tt-forge-fe'
+        required: true
+      workflow_allow_failed:
+        description: 'Run even if workflow has failed'
         required: false
-        default: ''
+        type: boolean
+        default: false
+      commit:
+        description: "Commit sha if you want to override release branch selection by last passing workflow"
+        required: false
+        type: string
 
 jobs:
-  get-repos:
-    outputs:
-      json_results: ${{ steps.get-repos.outputs.json_results }}
-    runs-on: ubuntu-latest
-    env:
-      GH_TOKEN: ${{ github.token }}
-    steps:
-    - uses: actions/checkout@v4
-    - name: Get Repos
-      id: get-repos
-      uses: ./.github/actions/get-repos
-      with:
-        repos: ${{ inputs.only_repos }}
-    - name: echo json repos
-      run: echo ${{ steps.get-repos.outputs.repos }}
-
-  create-version-branches:
-    needs: get-repos
-    strategy:
-      fail-fast: false
-      matrix:
-        build: ${{fromJson(needs.get-repos.outputs.json_results)}}
-    env:
-        GH_TOKEN: ${{ github.token }}
+  create-version-branch:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: version tag
-      id: version-tag
-      run: |
-        source .version
-        echo "MAJOR=$MAJOR" >> $GITHUB_OUTPUT
-        #TODO: Minor will be reset by the stable releaser when create a new release branch
-        echo "MINOR=$MINOR" >> $GITHUB_OUTPUT
-
-    - name: Set Release Facts
-      id: set-release-facts
-      uses: ./.github/actions/set-release-facts
-      with:
-        repo: ${{ matrix.build.repo }}
-        release_type: 'rc'
-
-    #TODO: Need to check on if we want to create rc branch for stable release (idempotent)
-    - name: Create Version branch - ${{ matrix.build.repo }}
+    - name: Create Version branch - ${{ inputs.repo }}
       id: create-rc-branch
       uses: ./.github/actions/create-rc-branch
       with:
-        repo: ${{ matrix.build.repo }}
-        workflow: ${{ steps.set-release-facts.outputs.workflow }}
-        MAJOR: ${{ steps.version-tag.outputs.MAJOR }}
-        MINOR: ${{ steps.version-tag.outputs.MINOR }}
-        draft: ${{ inputs.draft }}
-        GH_TOKEN: ${{ secrets.GH_TOKEN }}
-
-    - name: Releaser - ${{ matrix.build.repo }} - ${{ steps.create-rc-branch.outputs.branch_name }} - ${{ steps.create-rc-branch.outputs.tag_name }}
-      uses: ./.github/actions/releaser
-      with:
-        repo: ${{ matrix.build.repo }}
-        branch: ${{ steps.create-rc-branch.outputs.branch_name }}
-        release_type: 'rc'
-        # TODO: empty latest_branch_commit will be used for nightly releases
-        new_version_tag: ${{ steps.create-rc-branch.outputs.tag_name }}
-        draft: ${{ inputs.draft }}
+        repo: ${{ inputs.repo }}
+        draft: ${{ inputs.draft || false }}
+        workflow_allow_failed: ${{ inputs.workflow_allow_failed || false }}
+        GH_TOKEN: ${{ secrets.TT_FORGE_RELEASER }}

--- a/.github/workflows/test-releaser.yml
+++ b/.github/workflows/test-releaser.yml
@@ -68,13 +68,15 @@ permissions:
   contents: write
 
 jobs:
-#  test-create-version-branches:
-#    uses: ./.github/workflows/create-version-branches.yml
-#    with:
-#      draft: true
-#      repo: ${{ inputs.repo }}
+  test-create-version-branches:
+    uses: ./.github/workflows/create-version-branches.yml
+    secrets: inherit
+    with:
+      draft: ${{ inputs.draft || true }}
+      repo: ${{ inputs.repo || 'tenstorrent/tt-forge' }}
+      workflow_allow_failed: ${{ inputs.workflow_allow_failed || false }}
+
   test-daily-releaser:
-    #needs: test-create-version-branches
     if: github.event.pull_request.draft == false
     uses: ./.github/workflows/daily-releaser.yml
     secrets: inherit


### PR DESCRIPTION
Creates a release branch and a release candidate tag based on the tt-forge `.version` file in the repo's root.

This change will create a workflow dispatch command that takes a commit or automatically selects the latest workflow run that has passed its nightly.


Testing:
Added test workflow - https://github.com/tenstorrent/tt-forge/actions/runs/15842245128/job/44656946000?pr=180

Live test
https://github.com/tenstorrent/tt-forge/actions/runs/15842156180/job/44656708393#step:3:746

```bash
To https://github.com/tenstorrent/tt-forge-fe
   d458cbd5..4d525545  release-0.1 -> release-0.1
 * [new tag]           0.1.0rc1 -> 0.1.0rc1
Run actions/checkout@v4
```