### PR TITLE
Python requirements install in tests

### DIFF
--- a/.github/workflows/demo-tests.yml
+++ b/.github/workflows/demo-tests.yml
@@ -53,6 +53,8 @@ jobs:
           if [ -n "${{ matrix.demos.libreq }}" ]; then
             apt-get install -y -qq --no-install-recommends ${{ matrix.demos.libreq }}
           fi
+
+          source /venv-${{ matrix.demos.frontend }}/bin/activate
           if [ -n "${{ matrix.demos.pyreq }}" ]; then
             pip install ${{ matrix.demos.pyreq }}
           fi

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -77,6 +77,8 @@ jobs:
         if [ -n "${{ matrix.build.libreq }}" ]; then
           apt-get install -y -qq --no-install-recommends ${{ matrix.build.libreq }}
         fi
+
+        source /venv-${{ matrix.build.project }}/bin/activate
         if [ -n "${{ matrix.build.pyreq }}" ]; then
           pip install ${{ matrix.build.pyreq }}
         fi


### PR DESCRIPTION
Add the `source` command before installing python requirements.