### PR TITLE
Fix setup.py for forge-nightly

### DIFF
--- a/.github/scripts/template-setup.py
+++ b/.github/scripts/template-setup.py
@@ -14,4 +14,5 @@ setup(
         "pjrt-plugin-tt @https://pypi.eng.aws.tenstorrent.com/pjrt-plugin-tt/pjrt_plugin_tt-${NEW_VERSION_TAG}-py3-none-linux_x86_64.whl",
     ],
     python_requires=">=3.10",
+    py_modules=[],
 )

--- a/.github/workflows/test-releaser.yml
+++ b/.github/workflows/test-releaser.yml
@@ -8,6 +8,7 @@ on:
         - '.github/scripts/model-compatible-table/**'
         - '.github/scripts/wheel-version-updater.sh'
         - '.github/scripts/prune-nightly-branches.sh'
+        - '.github/scripts/wait-on-tt-pypi-wheels.sh'
         - '.github/workflows/update-release.yml'
         - '.github/workflows/daily-releaser.yml'
         - '.github/workflows/nightly-release.yml'
@@ -24,6 +25,8 @@ on:
         - '.github/actions/publish-tenstorrent-pypi/**'
         - '.github/actions/publish-github-release/**'
         - '.github/workflows/test-releaser.yml'
+        - '.github/scripts/pyproject.toml'
+        - '.github/scripts/template-setup.py'
     pull_request:
       types: [opened, synchronize, reopened, ready_for_review]
       branches: [ "main" ]
@@ -31,6 +34,7 @@ on:
         - '.github/scripts/model-compatible-table/**'
         - '.github/scripts/wheel-version-updater.sh'
         - '.github/scripts/prune-nightly-branches.sh'
+        - '.github/scripts/wait-on-tt-pypi-wheels.sh'
         - '.github/workflows/update-release.yml'
         - '.github/workflows/daily-releaser.yml'
         - '.github/workflows/nightly-release.yml'
@@ -47,6 +51,8 @@ on:
         - '.github/actions/publish-tenstorrent-pypi/**'
         - '.github/actions/publish-github-release/**'
         - '.github/workflows/test-releaser.yml'
+        - '.github/scripts/pyproject.toml'
+        - '.github/scripts/template-setup.py'
     workflow_dispatch:
       inputs:
         repo:


### PR DESCRIPTION
Github python action seems to update their setup tools to 61.X where it looks for packages by default.

This change disables it.

```
Successfully installed wheel-0.45.1
/opt/hostedtoolcache/Python/3.10.18/x64/lib/python3.10/site-packages/setuptools/_distutils/dist.py:264: UserWarning: Unknown distribution option: 'homepage'
  warnings.warn(msg)
error: Multiple top-level packages discovered in a flat-layout: ['demos', 'basic_tests', 'third_party'].
```
https://github.com/tenstorrent/tt-forge/actions/runs/15919423057/job/44902988519#step:5:337