### PR TITLE
Add tt-torch llama 3.2 3b generation demo

### DIFF
--- a/.github/workflows/demo-tests.yml
+++ b/.github/workflows/demo-tests.yml
@@ -38,7 +38,7 @@ jobs:
           - demos: { "frontend": "tt-torch", "demo": "llama_7b_pipeline_parallel.py", pyreq: "loguru requests transformers==4.52.4 datasets torchvision pytest tabulate accelerate" }
             runs-on: tt-beta-ubuntu-2204-n300-large-stable
           - demos: { "frontend": "tt-torch", "demo": "llama3.2_generate_demo.py", pyreq: "transformers==4.52.4" }
-            runs-on: tt-beta-ubuntu-2204-n300-large-stable
+            runs-on: tt-beta-ubuntu-2204-n150-large-stable
 
     runs-on: ${{ matrix.runs-on }}
     container:

--- a/.github/workflows/demo-tests.yml
+++ b/.github/workflows/demo-tests.yml
@@ -37,6 +37,8 @@ jobs:
         include:
           - demos: { "frontend": "tt-torch", "demo": "llama_7b_pipeline_parallel.py", pyreq: "loguru requests transformers==4.52.4 datasets torchvision pytest tabulate accelerate" }
             runs-on: tt-beta-ubuntu-2204-n300-large-stable
+          - demos: { "frontend": "tt-torch", "demo": "llama3.2_generate_demo.py", pyreq: "transformers==4.52.4" }
+            runs-on: tt-beta-ubuntu-2204-n300-large-stable
 
     runs-on: ${{ matrix.runs-on }}
     container:

--- a/demos/tt-torch/README.md
+++ b/demos/tt-torch/README.md
@@ -51,3 +51,11 @@ The `llama_7b_pipeline_parallel.py` script will split a large language model (Ll
 ```
 python demos/tt-torch/llama_7b_pipeline_parallel.py
 ```
+
+## Generative Models (llama3.2_generate_demo.py)
+
+The `llama3.2_generate_demo.py` script demonstrates a text generation loop using the llama 3.2 3B parameter model. It shows usage of an on-device static kv-cache shared between prefill and decode stages, and produces a stream of output tokens.
+
+```
+python demos/tt-torch/llama3.2_generate_demo.py
+```

--- a/demos/tt-torch/llama3.2_generate_demo.py
+++ b/demos/tt-torch/llama3.2_generate_demo.py
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch
+from tt_torch.tools.utils import CompilerConfig
+from tt_torch.tools.device_manager import DeviceManager
+from tt_torch.dynamo.backend import backend, BackendOptions
+from transformers import (
+    AutoTokenizer,
+    AutoModelForCausalLM,
+    StaticCache,
+)
+import time
+
+_global_max_cache_len = 64 + 64
+
+
+def clear_dynamo_cache():
+    # taken from/ inspired by: https://github.com/pytorch/pytorch/issues/107444
+    import torch._dynamo as dynamo
+    import gc
+
+    dynamo.reset()  # clear cache
+    gc.collect()
+
+
+def load_model(model_name="meta-llama/Llama-3.2-3B"):
+    # set up the model and tokenizer
+    model = AutoModelForCausalLM.from_pretrained(
+        model_name,
+        torch_dtype=torch.bfloat16,
+        use_cache=True,
+    )
+
+    tokenizer = AutoTokenizer.from_pretrained(model_name, torch_dtype=torch.bfloat16)
+    tokenizer.pad_token = tokenizer.eos_token
+    return model.eval(), tokenizer
+
+
+def load_inputs(
+    model,
+    tokenizer,
+    test_input="This is a sample text from ",
+    max_cache_len=_global_max_cache_len,
+):
+    batch_size = 1
+    inputs = tokenizer.encode_plus(
+        test_input,
+        return_tensors="pt",
+        truncation=True,
+    )
+
+    # set up static cache
+    static_cache = StaticCache(
+        config=model.config,
+        max_batch_size=batch_size,
+        max_cache_len=max_cache_len,
+        device=model.device,
+        dtype=model.dtype,
+    )
+
+    cache_position = torch.arange(0, inputs.input_ids.shape[1])
+
+    args = {
+        "input_ids": inputs.input_ids,
+        "past_key_values": static_cache,
+        "use_cache": True,
+        "cache_position": cache_position,
+    }
+    return args
+
+
+@torch.inference_mode()
+def main():
+    model, tokenizer = load_model()
+    input_args = load_inputs(model, tokenizer)
+    generated_ids = input_args["input_ids"]
+
+    clear_dynamo_cache()
+    cc = CompilerConfig()
+    cc.enable_consteval = False
+    cc.consteval_parameters = False
+
+    options = BackendOptions()
+    options.compiler_config = cc
+
+    device = DeviceManager.create_parent_mesh_device(mesh_shape=[1, 1])
+    options.devices = [device]
+
+    buffer_cache = {}
+    options.buffer_cache = buffer_cache
+
+    constant_cache = {}
+    options.constant_cache = constant_cache
+
+    compiled_model = torch.compile(model, backend=backend, dynamic=False, options=options)
+
+    # up to _global_max_cache_len - input_args["input_ids"].shape[1]
+    tokens_to_generate = 32
+
+    for i in range(tokens_to_generate):
+        print("\n===== Decode step", i, "=====\n")
+        print(f"Input args to step {i}", input_args)
+
+        start_time = time.time()
+
+        outputs = compiled_model(**input_args)
+
+        next_token_ids = outputs.logits[:, -1:].argmax(dim=-1)
+
+        generated_ids = torch.cat([generated_ids, next_token_ids], dim=-1)
+        print(
+            "Decoded output so far:",
+            "\033[91m",
+            tokenizer.decode(generated_ids[0].tolist()),
+            "\033[0m",
+        )
+        print("Time elapsed for this step: ", time.time() - start_time)
+        cache_position = input_args["cache_position"][-1:] + 1
+
+        input_args = {
+            "input_ids": next_token_ids.to(dtype=torch.int32),
+            "past_key_values": input_args["past_key_values"],  # updated in place
+            "cache_position": cache_position,
+            "use_cache": True,
+        }
+
+    DeviceManager.release_parent_device(device)
+    clear_dynamo_cache()
+
+
+if __name__ == "__main__":
+    main()

--- a/demos/tt-torch/llama3.2_generate_demo.py
+++ b/demos/tt-torch/llama3.2_generate_demo.py
@@ -10,7 +10,6 @@ from transformers import (
     AutoModelForCausalLM,
     StaticCache,
 )
-import time
 
 _global_max_cache_len = 64 + 64
 
@@ -75,6 +74,7 @@ def main():
     model, tokenizer = load_model()
     input_args = load_inputs(model, tokenizer)
     generated_ids = input_args["input_ids"]
+    print(tokenizer.decode(generated_ids[0].tolist()), end="", flush=True)
 
     clear_dynamo_cache()
     cc = CompilerConfig()
@@ -99,32 +99,19 @@ def main():
     tokens_to_generate = 32
 
     for i in range(tokens_to_generate):
-        print("\n===== Decode step", i, "=====\n")
-        print(f"Input args to step {i}", input_args)
-
-        start_time = time.time()
-
         outputs = compiled_model(**input_args)
-
         next_token_ids = outputs.logits[:, -1:].argmax(dim=-1)
-
         generated_ids = torch.cat([generated_ids, next_token_ids], dim=-1)
-        print(
-            "Decoded output so far:",
-            "\033[91m",
-            tokenizer.decode(generated_ids[0].tolist()),
-            "\033[0m",
-        )
-        print("Time elapsed for this step: ", time.time() - start_time)
-        cache_position = input_args["cache_position"][-1:] + 1
+        print(tokenizer.decode(next_token_ids[0].tolist()), end="", flush=True)
 
+        cache_position = input_args["cache_position"][-1:] + 1
         input_args = {
             "input_ids": next_token_ids.to(dtype=torch.int32),
             "past_key_values": input_args["past_key_values"],  # updated in place
             "cache_position": cache_position,
             "use_cache": True,
         }
-
+    print()  # Add a newline at the end of the output
     DeviceManager.release_parent_device(device)
     clear_dynamo_cache()
 


### PR DESCRIPTION
This PR adds a new Llama 3.2 3B text generation demo for tt-torch. 

The demo showcases autoregressive text generation through the tt-torch backend, featuring static KV caching and step-by-step token generation with timing information.