### PR TITLE
Fix readmes tt-xla mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ flowchart TD
 
 - [tt-xla](https://github.com/tenstorrent/tt-xla)
   - Leverages a PJRT interface to integrate JAX (and in the future other frameworks), `tt-mlir` and Tenstorrent hardware. Supports ingestion of JAX models via jit compile, providing StableHLO (SHLO) graph to `tt-mlir` compiler
-  - See [README](https://github.com/tenstorrent/tt-xla/blob/main/README.md) for an overview and getting started guide.
+  - See [docs pages](https://docs.tenstorrent.com/tt-xla) for an overview and getting started guide.
 
 
 ## [tt-mlir](https://github.com/tenstorrent/tt-mlir) Project

--- a/demos/README.md
+++ b/demos/README.md
@@ -4,18 +4,18 @@ This directory contains demonstration examples for three different frontends ava
 
 ## Available Frontends
 
-### [`tt-forge-fe/`](tt-forge-fe/)
+### [`tt-forge-fe`](https://github.com/tenstorrent/tt-forge-fe)
 The Frontend Engine (FE) provides a high-level interface for deploying popular deep learning models. It includes ready-to-use implementations of common CNN and NLP models like ResNet, MobileNet, and BERT.
 
-### [`tt-torch/`](https://github.com/tenstorrent/tt-torch)
+### [`tt-torch`](https://github.com/tenstorrent/tt-torch)
 A PyTorch-based frontend that enables seamless deployment of PyTorch models on Tenstorrent hardware. This frontend provides familiar PyTorch workflows while leveraging Tenstorrent's acceleration capabilities.
 
-### [`tt-xla/`](https://github.com/tenstorrent/tt-xla)
-An XLA-based frontend that supports JAX and TensorFlow models. This enables users to deploy models from these frameworks directly to Tenstorrent hardware while maintaining their existing development workflow.
+### [`tt-xla`](https://github.com/tenstorrent/tt-xla)
+An XLA-based frontend that natively supports JAX models and has support for PyTorch models through [PyTorch/XLA](https://pytorch.org/xla). This enables users to deploy models from these frameworks directly to Tenstorrent hardware while maintaining their existing development workflow.
 
 Each frontend is designed to support different ML frameworks and workflows. Choose the frontend that best matches your needs:
 - Use `tt-forge-fe` for quick deployment of pre-optimized common models
 - Use `tt-torch` for PyTorch model deployment
-- Use `tt-xla` for JAX and TensorFlow model deployment
+- Use `tt-xla` for JAX model deployment
 
 For more information, visit our [GitHub repositories](https://github.com/tenstorrent) or check the README in each frontend's directory.


### PR DESCRIPTION
- Added link to tt-xla docs website instead of pointing to repo .md file
- Fixed wrong mentions of Tensorflow support for tt-xla
- Fixed wrong link in demos readme for tt-forge-fe (it pointed to demos folder while other frontends links pointed to their docs)