### PR TITLE
Skip if RC release branch found, remove pypi install test, fix workflow dispatch on create RC

### DIFF
--- a/.github/actions/create-rc-branch/action.yml
+++ b/.github/actions/create-rc-branch/action.yml
@@ -64,6 +64,9 @@ outputs:
   current_release_tag_commit:
     description: "Current release tag commit"
     value: ${{ steps.get-release-branch.outputs.current_release_tag_commit }}
+  branch_exists:
+    description: "Branch exists"
+    value: ${{ steps.get-release-branch.outputs.branch_exists }}
 
 runs:
   using: "composite"
@@ -125,19 +128,26 @@ runs:
         # Set export commit sha and branch for git_facts.sh
         export branch="${{ steps.create-rc-branch.outputs.branch_name }}"
         tag_name="${{ steps.create-rc-branch.outputs.tag_name }}"
+        branch_exists=false
+
 
         check_branch=$(git ls-remote origin $branch)
 
         if [[ -z "$check_branch" ]]; then
             git checkout -b $branch ${{ steps.find_workflow.outputs.run-commit-sha }}
             git push origin $branch
+        else
+            echo "Release branch: $branch already exists. If you need to recreate a new branch for RC release, please delete the existing branch: ${branch}, the tag: ${tag_name}, and the GH release: ${tag_name} on repo: ${{ inputs.repo }}. Then start this process again"
+            branch_exists=true
         fi
 
         wget -q https://raw.githubusercontent.com/tenstorrent/tt-forge/refs/heads/${{ github.head_ref || github.ref_name }}/.github/scripts/git_facts.sh
         chmod +x git_facts.sh
-        ls -al
         # Call twice for GHA workflow logs and to store in github output
         ./git_facts.sh
+        echo "branch_exists=$branch_exists"
+        echo "tag_name=$tag_name"
+        echo "branch_exists=$branch_exists" >> $GITHUB_OUTPUT
         ./git_facts.sh >> $GITHUB_OUTPUT
 
 

--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -66,7 +66,7 @@ runs:
 
           TAGS="--tag $IMAGE_NAME:$DOCKER_TAG"
           if [[ "${{ inputs.make_latest }}" == "true" ]]; then
-            TAGS=+" --tag $IMAGE_NAME:latest"
+            TAGS+=" --tag $IMAGE_NAME:latest"
           fi
           echo "TAGS=${TAGS}"
           set -x

--- a/.github/actions/publish-tenstorrent-pypi/action.yml
+++ b/.github/actions/publish-tenstorrent-pypi/action.yml
@@ -73,22 +73,15 @@ runs:
           fi
         done
 
-    - name: Test Tenstorrent PYPI package install
+    - name: Verify Tenstorrent package is in PyPI
       shell: bash
       run: |
-        set -x
+        new_version_tag="${{ inputs.new_version_tag }}"
+        echo "new_version_tag=$new_version_tag"
         pip_wheel_names="${{ steps.set-release-facts.outputs.pip_wheel_names }}"
+        echo "pip_wheel_names=$pip_wheel_names"
+
         for wheel_name in $pip_wheel_names; do
           # Check the only tenstorrent index for the wheel version
-          pip index versions $wheel_name --pre --index-url https://pypi.eng.aws.tenstorrent.com/ | grep ${{ inputs.new_version_tag }}
-          if [ "${{ steps.set-release-facts.outputs.skip_wheel_install }}" == "false" ]; then
-            # Test install wheel version.
-            pip install $wheel_name==${{ inputs.new_version_tag }} --no-cache-dir --extra-index-url https://pypi.eng.aws.tenstorrent.com/
-            # Wheel import wheel
-            # TODO: skip import test until wheels are fixed
-            #normalized_import=$(echo "$wheel_name" | sed -e 's/-/_/g')
-            #python -c "import $normalized_import"
-            # Check installed version of wheel
-            pip show $wheel_name | grep ${{ inputs.new_version_tag }}
-          fi
+          pip index versions $wheel_name --pre --index-url https://pypi.eng.aws.tenstorrent.com/ | grep $new_version_tag
         done

--- a/.github/workflows/create-version-branches.yml
+++ b/.github/workflows/create-version-branches.yml
@@ -101,7 +101,7 @@ jobs:
       with:
         repo: ${{ steps.set-release-facts.outputs.draft == 'true' && 'tenstorrent/tt-forge' || steps.set-release-facts.outputs.repo_full }}
         draft: ${{steps.set-release-facts.outputs.draft == 'true' || false }}
-        workflow_allow_failed: ${{ steps.set-release-facts.outputs.workflow_allow_failed }}
+        workflow_allow_failed: ${{ inputs.workflow_allow_failed || steps.set-release-facts.outputs.workflow_allow_failed }}
         GH_TOKEN: ${{ secrets.TT_FORGE_RELEASER }}
         draft_slug_name: ${{ inputs.draft_slug_name || '' }}
         workflow: ${{ inputs.workflow || steps.set-release-facts.outputs.workflow }}
@@ -113,7 +113,9 @@ jobs:
         commit: ${{ inputs.commit }}
         override_release_fact_workflow: ${{ inputs.override_release_fact_workflow || '' }}
 
+
   create-rc-initial-release:
+    if: ${{ needs.create-version-branch.outputs.branch_exists == 'false' }}
     needs:
       - create-version-branch
     name: ${{ inputs.draft == 'true' && 'Draft' || '' }} ${{ inputs.repo_short }} RC Release


### PR DESCRIPTION
- Added gates to skip Release branch creation if it already exists
- Fix bug on tagging the latest on the docker image
- Fix bug on workflow dispatch input for release branch creation
- Remove tt-pypi install test since this happens in the docker wheel container now