### PR TITLE
Fix docker nighly release wheel versions

### DIFF
--- a/.github/Dockerfile.tt-forge-slim
+++ b/.github/Dockerfile.tt-forge-slim
@@ -47,7 +47,7 @@ USER forge
 RUN FRONTEND=tt-forge-fe && \
     python -m venv venv-$FRONTEND && \
     source venv-$FRONTEND/bin/activate && \
-    WHL_VERSION=$(pip index versions $FRONTEND -i https://pypi.eng.aws.tenstorrent.com --pre 2>/dev/null | grep -oP 'Available versions: \K.*' | tr -d ' ' | cut -d',' -f1) && \
+    WHL_VERSION=$(pip index versions $FRONTEND -i https://pypi.eng.aws.tenstorrent.com --pre 2>/dev/null | grep -oP 'Available versions: \K.*' | tr -d ' ' | tr ',' '\n' | grep dev | head -n1) && \
     pip install https://pypi.eng.aws.tenstorrent.com/tt-forge-fe/tt_forge_fe-$WHL_VERSION-cp310-cp310-linux_x86_64.whl && \
     pip install https://pypi.eng.aws.tenstorrent.com/tt-tvm/tt_tvm-$WHL_VERSION-cp310-cp310-linux_x86_64.whl && \
     pip cache purge && rm -rf ~/.cache/pip
@@ -56,7 +56,7 @@ RUN FRONTEND=tt-forge-fe && \
 RUN FRONTEND=tt-torch && \
     python -m venv venv-$FRONTEND && \
     source venv-$FRONTEND/bin/activate && \
-    WHL_VERSION=$(pip index versions $FRONTEND -i https://pypi.eng.aws.tenstorrent.com --pre 2>/dev/null | grep -oP 'Available versions: \K.*' | tr -d ' ' | cut -d',' -f1) && \
+    WHL_VERSION=$(pip index versions $FRONTEND -i https://pypi.eng.aws.tenstorrent.com --pre 2>/dev/null | grep -oP 'Available versions: \K.*' | tr -d ' ' | tr ',' '\n' | grep dev | head -n1) && \
     pip install https://pypi.eng.aws.tenstorrent.com/tt-torch/tt_torch-$WHL_VERSION-cp310-cp310-linux_x86_64.whl && \
     pip cache purge && rm -rf ~/.cache/pip
 
@@ -64,7 +64,7 @@ RUN FRONTEND=tt-torch && \
 RUN FRONTEND=tt-xla && \
     python -m venv venv-$FRONTEND && \
     source venv-$FRONTEND/bin/activate && \
-    WHL_VERSION=$(pip index versions pjrt-plugin-tt -i https://pypi.eng.aws.tenstorrent.com --pre 2>/dev/null | grep -oP 'Available versions: \K.*' | tr -d ' ' | cut -d',' -f1) && \
+    WHL_VERSION=$(pip index versions pjrt-plugin-tt -i https://pypi.eng.aws.tenstorrent.com --pre 2>/dev/null | grep -oP 'Available versions: \K.*' | tr -d ' ' | tr ',' '\n' | grep dev | head -n1) && \
     pip install https://pypi.eng.aws.tenstorrent.com/pjrt-plugin-tt/pjrt_plugin_tt-$WHL_VERSION-py3-none-linux_x86_64.whl && \
     pip cache purge && rm -rf ~/.cache/pip
 

--- a/.github/workflows/mega-docker.yml
+++ b/.github/workflows/mega-docker.yml
@@ -7,13 +7,8 @@ on:
         description: 'Force rebuild of Docker images even if they exist'
         type: boolean
         default: false
-  workflow_call:
-    inputs:
-      version_tag:
-        description: 'Release version tag'
-        type: string
-        required: false
-        default: ''
+  schedule:
+    - cron: '0 7 * * *'
 
 
 permissions:


### PR DESCRIPTION
### Changes

- Use the **latest** nightly release wheels for building the tt-forge-slim docker image
- Trigger tt-forge-slim docker image bulid process on a schedule