### PR TITLE
Add demos for e2e passing models:set5

### DIFF
--- a/demos/tt-forge-fe/cnn/hardnet_demo.py
+++ b/demos/tt-forge-fe/cnn/hardnet_demo.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+# Hardnet Demo Script
+
+import forge
+from third_party.tt_forge_models.hardnet.pytorch import ModelLoader
+
+# Load model and input
+loader = ModelLoader()
+model = loader.load_model()
+inputs = loader.load_inputs()
+
+# Compile the model using Forge
+compiled_model = forge.compile(model, sample_inputs=[inputs])
+
+# Run inference on Tenstorrent device
+output = compiled_model(inputs)
+
+# Post-process the output
+loader.print_cls_results(output)

--- a/demos/tt-forge-fe/cnn/vovnet_demo.py
+++ b/demos/tt-forge-fe/cnn/vovnet_demo.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+# Vovnet Demo Script
+
+import forge
+from third_party.tt_forge_models.vovnet.pytorch import ModelLoader
+
+# Load model and input
+loader = ModelLoader()
+model = loader.load_model()
+inputs = loader.load_inputs()
+
+# Compile the model using Forge
+compiled_model = forge.compile(model, sample_inputs=[inputs])
+
+# Run inference on Tenstorrent device
+output = compiled_model(inputs)
+
+# Post-process the output
+loader.print_cls_results(output)

--- a/demos/tt-forge-fe/cnn/yolox_demo.py
+++ b/demos/tt-forge-fe/cnn/yolox_demo.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+# Yolox Demo Script
+import os
+import forge
+from third_party.tt_forge_models.yolox.pytorch import ModelLoader
+from third_party.tt_forge_models.tools.utils import get_file
+
+# Load model and input
+loader = ModelLoader()
+model = loader.load_model()
+inputs = loader.load_inputs()
+
+# Compile the model using Forge
+compiled_model = forge.compile(model, sample_inputs=[inputs])
+
+# Run inference on Tenstorrent device
+output = compiled_model(inputs)
+
+# Post-process the output
+loader.post_processing(output)
+
+# Remove the cached .pth weight file
+model_name = loader.model_variant.replace("-", "_")
+weight_url = f"https://github.com/Megvii-BaseDetection/YOLOX/releases/download/0.1.1rc0/{model_name}.pth"
+weight_path = get_file(weight_url)
+
+# Clean up the downloaded model file
+if weight_path.exists():
+    os.remove(weight_path)
+    print(f"Removed downloaded weight file: {weight_path}")

--- a/demos/tt-forge-fe/nlp/albert_demo.py
+++ b/demos/tt-forge-fe/nlp/albert_demo.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+# Albert Demo Script
+
+import forge
+from third_party.tt_forge_models.albert.masked_lm.pytorch import ModelLoader
+
+# Load model and input
+loader = ModelLoader()
+model = loader.load_model()
+inputs = loader.load_inputs()
+
+# Compile the model using Forge
+compiled_model = forge.compile(model, sample_inputs=[inputs["input_ids"], inputs["attention_mask"]])
+
+# Run inference on Tenstorrent device
+output = compiled_model(inputs["input_ids"], inputs["attention_mask"])
+
+# Decode the output
+predicted_token_id = loader.decode_output(output)
+print("The predicted token for the [MASK] is: ", predicted_token_id)


### PR DESCRIPTION
This PR adds demos for the following models:

- Hardnet
- Vovnet
- Yolox
- Albert

Logs:
[yolox.log](https://github.com/user-attachments/files/21118902/yolox.log)
[hardnet.log](https://github.com/user-attachments/files/21118907/hardnet.log)
[vovnet1.log](https://github.com/user-attachments/files/21118917/vovnet1.log)
[albert.log](https://github.com/user-attachments/files/21118921/albert.log)
