### PR TITLE
bug: fix build_release_find_workflow_branch

### DIFF
--- a/.github/actions/set-release-facts/action.yaml
+++ b/.github/actions/set-release-facts/action.yaml
@@ -63,9 +63,9 @@ outputs:
   build_release_tag:
     description: "Build release tag"
     value: ${{ steps.set-manifest.outputs.build_release_tag }}
-  build_find_workflow_branch:
+  build_release_find_workflow_branch:
     description: "Build find workflow branch"
-    value: ${{ steps.set-manifest.outputs.build_find_workflow_branch }}
+    value: ${{ steps.set-manifest.outputs.build_release_find_workflow_branch }}
   workflow_allow_failed:
     description: "Return run even if workflow has failed"
     value: ${{ steps.set-manifest.outputs.workflow_allow_failed }}
@@ -215,6 +215,9 @@ runs:
             # null out the commit to so e2e testing can pick up the arfiacts from the repo.
             # This is because this commit belongs to the tt-forge repo not where the artifacts are stored.
             build_release_latest_branch_commit=""
+
+            # Used in testing to pick up the arfiacts from the main branch.
+            build_release_find_workflow_branch="main"
 
             # build_release_tag is a sanitized version tag for build_release action.
             # Tag sanitization only needs to happen for rc and stable release. See get-branches for more detail.

--- a/.github/actions/trigger-workflow/action.yml
+++ b/.github/actions/trigger-workflow/action.yml
@@ -16,6 +16,12 @@ inputs:
     description: "Parameters to pass to workflow"
     required: false
 
+
+outputs:
+  run_head_sha:
+    description: "Head SHA of the workflow run"
+    value: ${{ steps.wait-workflow.outputs.run_head_sha }}
+
 runs:
   using: "composite"
   steps:
@@ -40,6 +46,7 @@ runs:
 
     - name: Wait for workflow run
       if: ${{ inputs.wait }}
+      id: wait-workflow
       uses: ./.github/actions/wait-workflow
       with:
         workflow_name: ${{ inputs.workflow_name }}

--- a/.github/actions/wait-workflow/action.yml
+++ b/.github/actions/wait-workflow/action.yml
@@ -8,10 +8,15 @@ inputs:
     description: "Branch name"
     required: false
 
+outputs:
+  run_head_sha:
+    description: "Head SHA of the workflow run"
+    value: ${{ steps.wait-workflow.outputs.run_head_sha }}
 runs:
   using: "composite"
   steps:
     - name: Wait for workflow run
+      id: wait-workflow
       shell: bash
       run: |
         workflow_name="${{ inputs.workflow_name }}"
@@ -24,7 +29,10 @@ runs:
         echo "Waiting for workflow run $workflow_name on branch $branch to complete"
         while [ -z "$run_id" ]; do
           run_id=$(gh run list --workflow="$workflow_name" --branch $branch -L 1 --json databaseId | jq -r '.[].databaseId')
+          run_head_sha=$(gh run list --workflow="$workflow_name" --branch $branch -L 1 --json headSha | jq -r '.[].headSha')
           sleep 1
         done
         gh run watch $run_id
         echo "Workflow run completed"
+        echo "run_head_sha=$run_head_sha"
+        echo "run_head_sha=$run_head_sha" >> $GITHUB_OUTPUT

--- a/.github/workflows/test-rc-stable-release-lifecycle.yml
+++ b/.github/workflows/test-rc-stable-release-lifecycle.yml
@@ -85,12 +85,15 @@ jobs:
           repo: 'tt-mlir'
 
   mock-successful-workflow-pre-release-branch:
+    outputs:
+      run_head_sha: ${{ steps.trigger-workflow.outputs.run_head_sha }}
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/trigger-workflow
+        id: trigger-workflow
         with:
           workflow_name: 'Mock Successful'
           wait: true
@@ -112,7 +115,7 @@ jobs:
       draft_slug_name: ${{ matrix.repo_short }}
       workflow_allow_failed: false
       workflow: 'Mock Successful'
-      branch: ${{ github.head_ref }}
+      commit: ${{ needs.mock-successful-workflow-pre-release-branch.outputs.run_head_sha }}
       ignore_artifacts: true
 
   get-release-branches:


### PR DESCRIPTION
Fixed bug where the branch constraint was not being honored when picking up a wheel artifact with the find workflow action. In this case, the `main` branch wasn't being used, and in this test workflow, it was picking up artifacts from a developer's branch.

Error output
```bash
Search the lastest 300 workflow runs on branch:  workflow: On push
Using Workflow Run: https://github.com/tenstorrent/tt-mlir/actions/runs/16227877880 on branch: svuckovic/tt-alchemist-poc commit: 95446c9f6c35e509cd89e9edbbebc8bdefffcb1f run_id: 16227877880 run_conclusion: failure
```
https://github.com/tenstorrent/tt-forge/actions/runs/16229795654/job/45830076062#step:5:357

This bug has only affected nightly builds since [0.1.0.dev20250702](https://github.com/tenstorrent/tt-forge/releases/tag/0.1.0.dev20250702) since this bug was introduced in https://github.com/tenstorrent/tt-forge/commit/6331dfd491246fabd5ccbbd8183d631df463286a

This did not affect RC selection & Beta promotion since only commits are used to select workflows.

RC:
https://github.com/tenstorrent/tt-forge/actions/runs/16052599421/job/45298919722#step:5:356
Beta:
https://github.com/tenstorrent/tt-forge/actions/runs/16052782415/job/45299485248#step:5:356

Fixed output
```bash
Search the lastest 300 workflow runs on branch: main workflow: On push
Using Workflow Run: https://github.com/tenstorrent/tt-mlir/actions/runs/16225226352 on branch: main commit: ba6cc1e200d916f796311cbee3931bf6dc9a4603 run_id: 16225226352 run_conclusion: success
```
https://github.com/tenstorrent/tt-forge/actions/runs/16230162949/job/45831183670?pr=265#step:5:357


Changes were also made to the test-rc-stable-release-lifecycle.yml to use commit only instead of branch to mirror the workflow dispatch call of `.github/workflows/create-version-branches.yml`

<img width="418" height="477" alt="image" src="https://github.com/user-attachments/assets/4fb822df-9e32-472e-b2a4-05144741de06" />

