### PR TITLE
Improve docker drafting & fix docker tag check on main

### DIFF
--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -33,6 +33,10 @@ inputs:
     type: string
     required: false
     default: ''
+  draft:
+    description: 'Draft mode'
+    type: boolean
+    default: false
 
 outputs:
   image_tag:
@@ -62,16 +66,19 @@ runs:
           IMAGE_NAME="${{ inputs.image_name }}"
           DOCKER_TAG="${{ inputs.docker_tag }}"
           BUILD_ARGS="${{ inputs.build_args }}"
+          DRAFT="${{ inputs.draft }}"
+          DOCKERFILE="${{ inputs.dockerfile }}"
           echo "IMAGE_NAME=$IMAGE_NAME"
           echo "DOCKER_TAG=$DOCKER_TAG"
           echo "BUILD_ARGS=$BUILD_ARGS"
+          echo "DRAFT=$DRAFT"
 
           # Check if image already exists and not forced to rebuild
-          if docker manifest inspect $IMAGE_NAME:$DOCKER_TAG &>/dev/null && [[ "$GITHUB_REF_NAME" != "main" ]] && [[ "${{ inputs.force_rebuild }}" != "true" ]]; then
+          if docker manifest inspect $IMAGE_NAME:$DOCKER_TAG &>/dev/null && [[ "${{ inputs.force_rebuild }}" != "true" ]]; then
             echo "Image $IMAGE_NAME:$DOCKER_TAG already exists, skipping build"
           else
             echo "Building image $IMAGE_NAME:$DOCKER_TAG"
-            docker build -f ${{ inputs.dockerfile }} $BUILD_ARGS -t $IMAGE_NAME:$DOCKER_TAG .
+            docker build -f $DOCKERFILE $BUILD_ARGS -t $IMAGE_NAME:$DOCKER_TAG .
             docker push $IMAGE_NAME:$DOCKER_TAG
             echo "Docker image size:"
             docker images --format "{{.Size}}" $IMAGE_NAME:$DOCKER_TAG
@@ -80,7 +87,7 @@ runs:
           fi
 
           TAGS="--tag $IMAGE_NAME:$DOCKER_TAG"
-          if [[ "${{ inputs.make_latest }}" == "true" ]]; then
+          if [[ "${{ inputs.make_latest }}" == "true" && "${{ inputs.draft }}" == "false" ]]; then
             TAGS+=" --tag $IMAGE_NAME:latest"
           fi
           echo "TAGS=${TAGS}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,15 +116,16 @@ jobs:
         unique_artifact_suffix: ${{ needs.generate-seed.outputs.id }}
         override_release_fact_workflow: ${{ inputs.override_release_fact_workflow }}
 
-    - name: Build Single Wheel Docker Image ${{ steps.set-release-facts.outputs.repo_short }} ${{ steps.set-release-facts.outputs.build_release_tag }}
+    - name: "${{ inputs.draft && 'Draft' || '' }} Build Single Wheel Docker Image ${{ steps.set-release-facts.outputs.repo_short }} ${{ steps.set-release-facts.outputs.build_release_tag }}"
       if: ${{ (steps.set-release-facts.outputs.skip_docker_build == 'false' && steps.check-tag.outputs.exists == 'false') || (steps.set-release-facts.outputs.skip_docker_build == 'false' && inputs.overwrite_releases) }}
       id: docker-build-push
       uses: ./.github/actions/docker-build-push
       with:
         image_name: "ghcr.io/tenstorrent/${{ steps.set-release-facts.outputs.repo_short }}-slim"
-        docker_tag: ${{ steps.set-release-facts.outputs.build_release_tag }}
+        docker_tag: "${{ steps.set-release-facts.outputs.gh_new_version_tag }}"
         make_latest: false
         force_rebuild: ${{ inputs.overwrite_releases }}
+        draft: ${{ inputs.draft }}
         dockerfile: ".github/Dockerfile.single-wheel-slim"
         build_args: "--build-arg REPO_SHORT=${{ steps.set-release-facts.outputs.repo_short }} --build-arg WHEEL_FILES_PATH=${{ steps.build-release-wheel.outputs.wheel_files_path }}"
 
@@ -186,14 +187,16 @@ jobs:
           artifact-ids: ${{ needs.build-release.outputs.release-artifacts-id }}
           path: ${{ github.workspace }}/release
 
-      - name: Set to latest Docker Image ${{ steps.set-release-facts.outputs.repo_short }} ${{ steps.set-release-facts.outputs.build_release_tag }}
+      - name: "${{ inputs.draft && 'Draft' || '' }} Set to latest Docker Image ${{ steps.set-release-facts.outputs.repo_short }} ${{ steps.set-release-facts.outputs.gh_new_version_tag }}"
         if: ${{  steps.set-release-facts.outputs.skip_docker_build == 'false' }}
         id: docker-build-push
         uses: ./.github/actions/docker-build-push
         with:
           image_name: "ghcr.io/tenstorrent/${{ steps.set-release-facts.outputs.repo_short }}-slim"
-          docker_tag: ${{ steps.set-release-facts.outputs.build_release_tag }}
+          docker_tag: "${{ steps.set-release-facts.outputs.gh_new_version_tag }}"
           make_latest: ${{ steps.set-release-facts.outputs.make_latest }}
+          draft: ${{ inputs.draft }}
+          dockerfile: ".github/Dockerfile.single-wheel-slim"
 
       - uses: ./.github/actions/publish-tenstorrent-pypi
         # Skip Wheel PyPI upload in workflow test


### PR DESCRIPTION
Changes:

**Use the draft tag for Docker testing and remove ignore tag check if on the main branch.**

```bash
Building image ghcr.io/tenstorrent/tt-torch-slim:0.2.0.dev20250715
ERROR: docker: 'docker buildx build' requires 1 argument

Usage:  docker buildx build [OPTIONS] PATH | URL | -
```
https://github.com/tenstorrent/tt-forge/actions/runs/16281527156/job/45972345217#step:5:313