### PR TITLE
Bug: Prefer latest_branch_commit over branch for release branch creation

### DIFF
--- a/.github/actions/find-workflow/action.yml
+++ b/.github/actions/find-workflow/action.yml
@@ -57,6 +57,7 @@ runs:
       id: fetch_run_id
       run: |
         loop_count=300
+        # Prefer commit id over branch when supplied
         if [[ -n "${{ inputs.override_release_fact_workflow }}" ]]; then
           if [[ -n "${{ inputs.commit }}" ]]; then
             echo "Search the lastest $loop_count workflow runs on commit: ${{ inputs.commit }}" on workflow: ${{ inputs.override_release_fact_workflow }}

--- a/.github/actions/set-release-facts/action.yaml
+++ b/.github/actions/set-release-facts/action.yaml
@@ -220,7 +220,7 @@ runs:
 
         # Testing Overrides
 
-        # Different tags exist for e2e testing for draft releases/test workflow. This is to guard against overwriting releases
+        # Different tags exist for integration testing for draft releases/test workflow. This is to guard against overwriting releases
         # We also can't use the draft style tag below since it won't work when we do a wheel re-version
         # REF: https://packaging.python.org/en/latest/discussions/versioning/#valid-version-numbers
         if [[ "${{ inputs.draft }}" == "true" ]]; then
@@ -229,8 +229,9 @@ runs:
             test_demo_filter="opt_125m"
             test_demo_wait="true"
 
-            # null out the commit to so e2e testing can pick up the arfiacts from the repo.
+            # null out the commit to so integration testing can pick up the arfiacts from the repo.
             # This is because this commit belongs to the tt-forge repo not where the artifacts are stored.
+            # Since this is null, it will pick up the artifacts based on branch
             build_release_latest_branch_commit=""
 
             # Used in testing to pick up the arfiacts from the main branch.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,6 +110,7 @@ jobs:
         draft: ${{ inputs.draft }}
         repo: ${{ steps.set-release-facts.outputs.repo_full }}
         release_type: ${{ inputs.release_type }}
+        latest_branch_commit: ${{ steps.set-release-facts.outputs.build_release_latest_branch_commit }}
         branch: ${{ inputs.branch || 'main' }}
         new_version_tag: ${{ steps.set-release-facts.outputs.build_release_tag }}
         unique_artifact_suffix: ${{ needs.generate-seed.outputs.random-seed }}


### PR DESCRIPTION
Fixes bug introduced during docker demo test in PR # https://github.com/tenstorrent/tt-forge/pull/271

https://github.com/tenstorrent/tt-forge/actions/runs/16419637927/job/46394396684#step:5:379

Working release branch trigger and test workflow (in PR)
https://github.com/tenstorrent/tt-forge/actions/runs/16425269114/job/46413957016#step:5:384

Merging to to cut RC1 for tt-xla


