### PR TITLE
bug: fix pip install gh release page docs

### DIFF
--- a/.github/actions/docs-generator/action.yml
+++ b/.github/actions/docs-generator/action.yml
@@ -224,11 +224,7 @@ runs:
         pip_install_instructions=""
         pip_wheel_names="${{ inputs.pip_wheel_names }}"
         for wheel_name in $pip_wheel_names; do
-            if [[ "${{ inputs.make_latest }}" == "true" ]]; then
-                pip_install_instructions+="pip install $wheel_name==${{ inputs.new_version_tag }} --extra-index-url https://pypi.eng.aws.tenstorrent.com/<br>"
-            else
-                pip_install_instructions+="pip install $wheel_name==${{ inputs.new_version_tag }} --pre --extra-index-url https://pypi.eng.aws.tenstorrent.com/<br>"
-            fi
+            pip_install_instructions+="pip install $wheel_name==${{ inputs.new_version_tag }} --extra-index-url https://pypi.eng.aws.tenstorrent.com/<br>"
         done
 
         echo "pip_install_instructions=$pip_install_instructions"


### PR DESCRIPTION

Issue:

The `--pre` option is pushed all the way down versus just the first level of the wheel file/setup.py file.

Fix:
Remove the `--pre` option
```bash
pip install tt-forge==0.2.0.dev20250720  --extra-index-url https://pypi.eng.aws.tenstorrent.com/
```

It was discovered by httpx choosing 1.0dev1 pre-release, which uses the --pre in its pip install, which affected its basic Docker test.

Mega docker build with (with uni wheel)
https://github.com/tenstorrent/tt-forge/actions/runs/16411965702/job/46368887696#step:6:1544

This has not affected other pip installs.

Mega docker build (with uni venv)
https://github.com/tenstorrent/tt-forge/actions/runs/16410742296/job/46375276904
Basic test run by daily releaser. [Use pip install by wheel file](https://github.com/tenstorrent/tt-forge/blob/main/.github/Dockerfile.single-wheel-slim#L56) no --pre
https://github.com/tenstorrent/tt-forge/actions/runs/16396787915/job/46330422497#step:6:1823
