### PR TITLE
Clean up release draft artifacts

### DIFF
--- a/.github/workflows/clean-release-tests.yml
+++ b/.github/workflows/clean-release-tests.yml
@@ -1,36 +1,31 @@
 name: Clean up release tests
+description: Clean up release test workflow artifacts every day
 on:
   workflow_call:
   workflow_dispatch:
   workflow_run:
     workflows:
-      - "Test Release RC/Stable Lifecycle"
-      - "Test Nightly Releaser"
+      - "Daily Releaser"
     types:
       - completed
 
 
 jobs:
-  delete-drafts:
+  clean-up-release-tests:
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
     steps:
-      - name: Wait for workflow run Test Release RC/Stable Lifecycle
-        uses: ./.github/actions/wait-workflow
-        with:
-          workflow_name: "Test Release RC/Stable Lifecycle"
-      - name: Wait for workflow run Test Nightly Releaser
-        uses: ./.github/actions/wait-workflow
-        with:
-          workflow_name: "Test Nightly Releaser"
       - name: Delete drafts releases
         uses: hugo19941994/delete-draft-releases@v1.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.TT_FORGE_RELEASER }}
-      - name: Delete draft-*-release-*.* branches
-        uses: dawidd6/action-delete-branch@v3
+      - uses: snok/container-retention-policy@v3.0.0
         with:
-          github_token: ${{ secrets.TT_FORGE_RELEASER }}
-          prefix: draft-*-release-*.*
-      - uses: fabriziocacicia/delete-tags-without-release-action@v0.1.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.TT_FORGE_RELEASER }}
+          account: tenstorrent
+          token: ${{ secrets.GH_TOKEN }}
+          image-names: "tt-*-slim"
+          image-tags: "draft.tt-*.dev*"
+          tag-selection: "tagged"
+          dry-run: false
+          cut-off: 1h

--- a/.github/workflows/test-nightly-releaser.yml
+++ b/.github/workflows/test-nightly-releaser.yml
@@ -67,14 +67,6 @@ on:
           description: 'Name of repo eg. tt-forge-fe'
           required: false
           default: ''
-        draft:
-          type: boolean
-          default: true
-          description: Put PR in draft mode for testing
-        delete-drafts:
-          type: boolean
-          default: true
-          description: Delete drafts
 
 permissions:
   pages: write

--- a/.github/workflows/test-rc-stable-release-lifecycle.yml
+++ b/.github/workflows/test-rc-stable-release-lifecycle.yml
@@ -206,3 +206,37 @@ jobs:
       draft: true
       repo: ${{ matrix.repo }}
       release_branch: ${{ matrix.branch }}
+
+  delete-draft-artifacts:
+    if: always()
+    needs:
+      - promote-stable
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout
+        if: ${{ inputs.delete-drafts || true }}
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Delete test tags
+        if: ${{ inputs.delete-drafts || true }}
+        run: |
+          set +e
+          draft_tags=$(git tag -l | grep -oP "^draft\.tt-\w+\.\d\.\d\.\d.*" | xargs)
+          set -e
+          echo "draft_tags=$draft_tags"
+          if [ -n "$draft_tags" ]; then
+            git push origin --delete $draft_tags
+          fi
+      - name: Delete draft branch branches
+        if: ${{ inputs.delete-drafts || true }}
+        run: |
+          set +e
+          draft_branches=$(git branch -r | grep -oP "(?<=origin\/)draft-tt-\w+-release-\d\.\d$" | xargs)
+          set -e
+          echo "draft_branches=$draft_branches"
+          if [ -n "$draft_branches" ]; then
+            git push origin --delete $draft_branches
+          fi


### PR DESCRIPTION
Changes:

- Cleans up draft tag and branch created by the `Test Release RC/Stable Lifecycle` test
- Triggers a draft clean-up of draft Docker images and GH release after a daily releaser run. We do this to save CI build time in the test workflow. 

Testing:

**Verified with a dry run that only draft tags and image tags would delete.**
https://github.com/tenstorrent/tt-forge/actions/runs/16455494110/job/46511386209#step:4:33

**Verified that will clean up tags and branches after `Test Release RC/Stable Lifecycle` lifecycle run**
https://github.com/tenstorrent/tt-forge/actions/runs/16455946346/job/46513161830#step:4:15
https://github.com/tenstorrent/tt-forge/actions/runs/16455946346/job/46513161830#step:3:15