### PR TITLE
bug: fix workflow_allow_failed input in RC & Stable creation

### DIFF
--- a/.github/actions/build-release-wheel/action.yml
+++ b/.github/actions/build-release-wheel/action.yml
@@ -35,6 +35,11 @@ inputs:
     required: false
     type: string
     default: ''
+  workflow_allow_failed:
+    description: "Ignore if workflow has failed"
+    required: false
+    type: boolean
+    default: false
 
 outputs:
   release-artifacts-id:
@@ -73,7 +78,7 @@ runs:
         repo: ${{ inputs.repo }}
         branch: ${{ steps.set-release-facts.outputs.build_release_find_workflow_branch }}
         workflow: ${{ steps.set-release-facts.outputs.workflow }}
-        workflow_allow_failed: ${{ steps.set-release-facts.outputs.workflow_allow_failed }}
+        workflow_allow_failed: ${{ inputs.workflow_allow_failed }}
         workflow_result_in_job: ${{ steps.set-release-facts.outputs.workflow_result_in_job }}
         commit: ${{ inputs.latest_branch_commit }}
         override_release_fact_workflow: ${{ inputs.override_release_fact_workflow }}

--- a/.github/workflows/create-version-branches.yml
+++ b/.github/workflows/create-version-branches.yml
@@ -102,7 +102,7 @@ jobs:
       with:
         repo: ${{ steps.set-release-facts.outputs.draft == 'true' && 'tenstorrent/tt-forge' || steps.set-release-facts.outputs.repo_full }}
         draft: ${{steps.set-release-facts.outputs.draft == 'true' || false }}
-        workflow_allow_failed: ${{ inputs.workflow_allow_failed || steps.set-release-facts.outputs.workflow_allow_failed }}
+        workflow_allow_failed: ${{ inputs.workflow_allow_failed }}
         GH_TOKEN: ${{ secrets.TT_FORGE_RELEASER }}
         draft_slug_name: ${{ inputs.draft_slug_name || '' }}
         workflow: ${{ inputs.workflow || steps.set-release-facts.outputs.workflow }}
@@ -132,3 +132,4 @@ jobs:
       latest_branch_commit: ${{ needs.create-version-branch.outputs.latest_branch_commit }}
       current_release_tag_commit: ${{ needs.create-version-branch.outputs.current_release_tag_commit }}
       override_release_fact_workflow: ${{ inputs.override_release_fact_workflow || '' }}
+      workflow_allow_failed: ${{ inputs.workflow_allow_failed }}

--- a/.github/workflows/promote-stable.yml
+++ b/.github/workflows/promote-stable.yml
@@ -21,6 +21,11 @@ on:
         required: false
         type: string
         default: ''
+      workflow_allow_failed:
+        description: "Ignore if workflow has failed"
+        required: false
+        type: boolean
+        default: false
 
 
   workflow_call:
@@ -43,6 +48,11 @@ on:
         required: false
         type: string
         default: ''
+      workflow_allow_failed:
+        description: "Ignore if workflow has failed"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   pages: write
@@ -119,3 +129,4 @@ jobs:
       latest_branch_commit: ${{ needs.get-facts.outputs.latest_branch_commit }}
       current_release_tag_commit: ${{ needs.get-facts.outputs.current_release_tag_commit }}
       override_release_fact_workflow: ${{ inputs.override_release_fact_workflow || '' }}
+      workflow_allow_failed: ${{ inputs.workflow_allow_failed }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,11 @@ on:
         description: 'Override release facts workflow'
         required: false
         default: ''
+      workflow_allow_failed:
+        description: "Ignore if workflow has failed"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   pages: write
@@ -115,6 +120,7 @@ jobs:
         new_version_tag: ${{ steps.set-release-facts.outputs.build_release_tag }}
         unique_artifact_suffix: ${{ needs.generate-seed.outputs.random-seed }}
         override_release_fact_workflow: ${{ inputs.override_release_fact_workflow }}
+        workflow_allow_failed: ${{ inputs.workflow_allow_failed || steps.set-release-facts.outputs.workflow_allow_failed }}
 
     - name: "${{ inputs.draft && 'Draft' || '' }} Build Single Wheel Docker Image ${{ steps.set-release-facts.outputs.repo_short }} ${{ steps.set-release-facts.outputs.build_release_tag }}"
       if: ${{ (steps.set-release-facts.outputs.skip_docker_build == 'false' && steps.check-tag.outputs.exists == 'false') || (steps.set-release-facts.outputs.skip_docker_build == 'false' && inputs.overwrite_releases) }}


### PR DESCRIPTION
Issue:

`workflow_allow_failed` input was not being pushed down to the releaser.yml

```bash
Search the lastest 300 workflow runs on commit: 7fb190ac0dc129e4145b0d119ecfd30cf0c938d9 workflow: On nightly
Skipping Workflow Run: https://github.com/tenstorrent/tt-forge-fe/actions/runs/16278835537 due to run failure run_conclusion: failure
```
https://github.com/tenstorrent/tt-forge/actions/runs/16472272523/job/46564409575#step:5:384

Changes:
- Fixed create version branch so this opt is being pushed down.
- Added this to promote stability to allow similar behavior.

Testing:

** Verified that RC promotes will default to `workflow_allow_failed: false`**
https://github.com/tenstorrent/tt-forge/actions/runs/16474037727/job/46570708502?pr=288#step:5:278

** Verified that Stable Promotes will default to  `workflow_allow_failed: false`**
https://github.com/tenstorrent/tt-forge/actions/runs/16474037727/job/46571089254?pr=288#step:5:278

** Verified that Nightly will still default to `workflow_allow_failed: true`**
https://github.com/tenstorrent/tt-forge/actions/runs/16474037834/job/46570667396?pr=288#step:5:278
