### PR TITLE
Add info about which ttrt wheel the perf tests are using

### DIFF
--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -197,9 +197,10 @@ jobs:
     - name: Find workflow run ID for ttrt wheel download
       id: find-run
       run: |
-        RUN_ID=$(gh api repos/tenstorrent/tt-mlir/actions/workflows/on-push.yml/runs \
-          --jq '.workflow_runs[] | select(.conclusion == "success" and .head_branch == "main") | .id' \
-          | head -1)
+        RUN_ID=$(curl -s \
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          "https://api.github.com/repos/tenstorrent/tt-mlir/actions/workflows/on-push.yml/runs?status=success&branch=main&per_page=1" \
+          | jq -r '.workflow_runs[0].id')
         echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
         echo "Workflow URL: https://github.com/tenstorrent/tt-mlir/actions/runs/$RUN_ID"
       env:


### PR DESCRIPTION
"Performance benchmark" tests are downloading the ttrt wheel from the latest, successful on-push pipeline from tt-mlir.

The PR prints out the workflow URL from which the ttrt wheel is taken.
This makes accessing the exact ttrt wheel easier for developers.