### PR TITLE
Bug: Revert "Fix the release process issue (#302)"

### DIFF
--- a/.github/actions/install-wheel/action.yml
+++ b/.github/actions/install-wheel/action.yml
@@ -27,7 +27,7 @@ runs:
           echo "artifact=forge-wheel" >> $GITHUB_OUTPUT
           echo "wheel_name=tt_*" >> $GITHUB_OUTPUT
         elif [ "${{ inputs.project }}" = "tt-torch" ]; then
-          echo "artifact=install-artifacts" >> $GITHUB_OUTPUT
+          echo "artifact=install-artifacts-release" >> $GITHUB_OUTPUT
           echo "wheel_name=wheels/tt_*" >> $GITHUB_OUTPUT
           echo "untar='true'" >> $GITHUB_OUTPUT
         elif [ "${{ inputs.project }}" = "tt-xla" ]; then

--- a/.github/actions/set-release-facts/action.yaml
+++ b/.github/actions/set-release-facts/action.yaml
@@ -186,7 +186,7 @@ runs:
             if [[ "${{ inputs.release_type }}" == "nightly" ]]; then
                 workflow="On push"
             fi
-            artifact_download_glob='*{install-artifacts,test-reports-models-}*'
+            artifact_download_glob='*{install-artifacts-release,test-reports-models-}*'
             artifact_cleanup_file_glob='*torchvision*'
             artifact_cleanup_folder_glob='*install-artifacts-debug*'
             pip_wheel_names="tt-torch"


### PR DESCRIPTION
This partially reverts commit 7b6eb4a7e6ee6f945d5f3e0a0d6f79054f9518b5 as it's causing a issue with nightly releases.

```bash
In wheel files path:
release/artifacts/tenstorrent/tt-torch/install-artifacts-release/wheels:
tt_torch-0.3.0.dev20250804-cp310-cp310-linux_x86_64.whl

release/artifacts/tenstorrent/tt-torch/install-artifacts/wheels:
tt_torch-0.3.0.dev20250804-cp310-cp310-linux_x86_64.whl
Error: Unable to process file command 'output' successfully.
Error: Invalid format 'release/artifacts/tenstorrent/tt-torch/install-artifacts/wheels'

```

https://github.com/tenstorrent/tt-forge/actions/runs/16715433205/job/47307889406#step:5:670

The issues is caused when both  `install-artifacts-release` and `install-artifacts`  is downloaded, both wheels are named tt_torch-0.1.whl which causes a conflict. We also only want install-artifacts-release since that doesn't compile with code coverage

```bash
~/work/tt-forge/tt-forge/release/artifacts/tenstorrent/tt-torch/install-artifacts-release/wheels ~/work/tt-forge/tt-forge
Unpacking to: tt_torch-0.1...OK
```
https://github.com/tenstorrent/tt-forge/actions/runs/16641278276/job/47091913390#step:5:580

```bash
~/work/tt-forge/tt-forge/release/artifacts/tenstorrent/tt-torch/install-artifacts/wheels ~/work/tt-forge/tt-forge
Unpacking to: tt_torch-0.1...OK
```
https://github.com/tenstorrent/tt-forge/actions/runs/16641278276/job/47091913390#step:5:605
