### PR TITLE
Add demo for Deepseek and GPT2 Models

### DIFF
--- a/demos/tt-forge-fe/nlp/deepseekcoder_demo.py
+++ b/demos/tt-forge-fe/nlp/deepseekcoder_demo.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+import forge
+from forge.verify.verify import verify
+from third_party.tt_forge_models.deepseek.deepseek_coder.pytorch import (
+    ModelLoader as CausalLMLoader,
+)
+import torch
+from third_party.tt_forge_models.deepseek.deepseek_coder.pytorch import (
+    ModelVariant as CausalLMVariant,
+)
+from transformers.modeling_attn_mask_utils import _prepare_4d_causal_attention_mask
+
+
+DEEPSEEK_VARIANTS = [
+    CausalLMVariant.DEEPSEEK_1_3B_INSTRUCT,
+]
+
+
+class DeepSeekWrapper(torch.nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+        self.embed_tokens = model.model.embed_tokens
+
+    def forward(self, input_tensor, attention_mask=None, past_key_values=None):
+        inputs_embeds = self.embed_tokens(input_tensor)
+        past_key_values_length = past_key_values[0][0].shape[-2] if past_key_values is not None else 0
+        causal_attention_mask = _prepare_4d_causal_attention_mask(
+            attention_mask, input_tensor.shape, inputs_embeds, past_key_values_length
+        )
+        return self.model(input_ids=input_tensor, attention_mask=causal_attention_mask).logits
+
+
+loader = CausalLMLoader()
+model = loader.load_model()
+framework_model = DeepSeekWrapper(model)
+framework_model.eval()
+tokenizer = loader._load_tokenizer()
+
+padded_inputs = loader.load_inputs()
+
+# Forge compile framework model
+compiled_model = forge.compile(
+    framework_model,
+    sample_inputs=[padded_inputs],
+)
+
+# Model Verification
+verify([padded_inputs], framework_model, compiled_model)
+
+generated_text = loader.decode_output(
+    max_new_tokens=512, model=compiled_model, inputs=padded_inputs, tokenizer=tokenizer
+)
+print(generated_text)

--- a/demos/tt-forge-fe/nlp/deepseekmath_demo.py
+++ b/demos/tt-forge-fe/nlp/deepseekmath_demo.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import forge
+from forge.verify.verify import verify
+from third_party.tt_forge_models.deepseek.deepseek_math.pytorch import (
+    ModelLoader as MathLoader,
+)
+from third_party.tt_forge_models.deepseek.deepseek_math.pytorch import (
+    ModelVariant as MathVariant,
+)
+
+DEEPSEEK_MATH_VARIANTS = [
+    MathVariant.DEEPSEEK_7B_INSTRUCT,
+]
+
+
+class DeepSeekWrapper(torch.nn.Module):
+    def __init__(self, model, max_new_tokens=200):
+        super().__init__()
+        self.model = model
+        self.max_new_tokens = max_new_tokens
+
+    def forward(self, input_tensor):
+        return self.model(input_tensor, max_new_tokens=self.max_new_tokens).logits
+
+
+# Load Model and Tokenizer
+loader = MathLoader(variant=MathVariant.DEEPSEEK_7B_INSTRUCT)
+model = loader.load_model()
+tokenizer = loader._load_tokenizer()
+framework_model = DeepSeekWrapper(model)
+framework_model.eval()
+
+# Prepare inputs
+padded_inputs = loader.load_inputs()
+
+# Compile model
+compiled_model = forge.compile(
+    framework_model,
+    sample_inputs=[padded_inputs],
+)
+
+# Verify correctness
+verify([padded_inputs], framework_model, compiled_model)
+
+# Generate output
+generated_text = loader.decode_output(
+    max_new_tokens=512,
+    model=compiled_model,
+    inputs=padded_inputs,
+    tokenizer=tokenizer,
+)
+print(generated_text)

--- a/demos/tt-forge-fe/nlp/gpt2_demo.py
+++ b/demos/tt-forge-fe/nlp/gpt2_demo.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import forge
+from forge.verify.verify import verify
+from third_party.tt_forge_models.gpt2.pytorch import ModelLoader, ModelVariant
+
+# Load model and inputs via ModelLoader
+loader = ModelLoader(variant=ModelVariant.GPT2_SEQUENCE_CLASSIFICATION)
+model = loader.load_model()
+inputs_dict = loader.load_inputs()
+inputs = [inputs_dict["input_ids"]]
+
+# Compile with Forge
+compiled_model = forge.compile(model, sample_inputs=inputs)
+
+# Run verification
+_, co_out = verify(inputs, model, compiled_model)
+
+# For classification variant, decode and print sentiment
+predicted_value = loader.decode_output(co_out)
+print(f"Predicted Sentiment: {predicted_value}")


### PR DESCRIPTION
### Problem description
This PR Includes the model demo from the tt_forge_models


### What's changed
The demo script for the deepseekmath,deepseekcoder,gpt2 for following modal has been added

### Checklist
- [x] New/Existing tests provide coverage for changes

### Model Log
[deepseek_coder_demo.log](https://github.com/user-attachments/files/21596399/deepseek_coder_demo.log)
[deepseek_math_demo.log](https://github.com/user-attachments/files/21596402/deepseek_math_demo.log)
[gpt2_demo.log](https://github.com/user-attachments/files/21596405/gpt2_demo.log)


