### PR TITLE
Omit caching when pip installing wheels for mega docker

### DIFF
--- a/.github/Dockerfile.tt-forge-slim
+++ b/.github/Dockerfile.tt-forge-slim
@@ -48,8 +48,8 @@ RUN FRONTEND=tt-forge-fe && \
     python -m venv venv-$FRONTEND && \
     source venv-$FRONTEND/bin/activate && \
     WHL_VERSION=$(pip index versions $FRONTEND -i https://pypi.eng.aws.tenstorrent.com --pre 2>/dev/null | grep -oP 'Available versions: \K.*' | tr -d ' ' | tr ',' '\n' | grep dev | head -n1) && \
-    pip install https://pypi.eng.aws.tenstorrent.com/tt-forge-fe/tt_forge_fe-$WHL_VERSION-cp310-cp310-linux_x86_64.whl && \
-    pip install https://pypi.eng.aws.tenstorrent.com/tt-tvm/tt_tvm-$WHL_VERSION-cp310-cp310-linux_x86_64.whl && \
+    pip install --no-cache-dir https://pypi.eng.aws.tenstorrent.com/tt-forge-fe/tt_forge_fe-$WHL_VERSION-cp310-cp310-linux_x86_64.whl && \
+    pip install --no-cache-dir https://pypi.eng.aws.tenstorrent.com/tt-tvm/tt_tvm-$WHL_VERSION-cp310-cp310-linux_x86_64.whl && \
     pip cache purge && rm -rf ~/.cache/pip
 
 # Create and activate virtual environment for tt-torch, install whl
@@ -57,7 +57,7 @@ RUN FRONTEND=tt-torch && \
     python -m venv venv-$FRONTEND && \
     source venv-$FRONTEND/bin/activate && \
     WHL_VERSION=$(pip index versions $FRONTEND -i https://pypi.eng.aws.tenstorrent.com --pre 2>/dev/null | grep -oP 'Available versions: \K.*' | tr -d ' ' | tr ',' '\n' | grep dev | head -n1) && \
-    pip install https://pypi.eng.aws.tenstorrent.com/tt-torch/tt_torch-$WHL_VERSION-cp310-cp310-linux_x86_64.whl && \
+    pip install --no-cache-dir https://pypi.eng.aws.tenstorrent.com/tt-torch/tt_torch-$WHL_VERSION-cp310-cp310-linux_x86_64.whl && \
     pip cache purge && rm -rf ~/.cache/pip
 
 # Create and activate virtual environment for tt-xla, install whl
@@ -65,7 +65,7 @@ RUN FRONTEND=tt-xla && \
     python -m venv venv-$FRONTEND && \
     source venv-$FRONTEND/bin/activate && \
     WHL_VERSION=$(pip index versions pjrt-plugin-tt -i https://pypi.eng.aws.tenstorrent.com --pre 2>/dev/null | grep -oP 'Available versions: \K.*' | tr -d ' ' | tr ',' '\n' | grep dev | head -n1) && \
-    pip install https://pypi.eng.aws.tenstorrent.com/pjrt-plugin-tt/pjrt_plugin_tt-$WHL_VERSION-py3-none-linux_x86_64.whl && \
+    pip install --no-cache-dir https://pypi.eng.aws.tenstorrent.com/pjrt-plugin-tt/pjrt_plugin_tt-$WHL_VERSION-py3-none-linux_x86_64.whl && \
     pip cache purge && rm -rf ~/.cache/pip
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
Mega docker build image job ran out of disk space when pip installing wheels and failed.

Added `--no-cache-dir` to `pip install` to avoid unnecessary caching and taking up of the disk space.