### PR TITLE
Check runners

### DIFF
--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -2,73 +2,270 @@ name: Performance benchmark
 
 on:
   workflow_dispatch:
+    inputs:
+      docker-image:
+        description: "Docker image used in tests"
+        required: false
+        type: string
+        default: "ghcr.io/tenstorrent/tt-forge/tt-forge-slim:latest"
+      project-filter:
+        description: "Project filter"
+        required: false
+        type: choice
+        options:
+          - tt-forge-fe
+          - tt-torch
+          - tt-xla
+          - All
+        default: All
+      test-filter:
+        description: "Only run tests that contains"
+        required: false
+        type: string
+      update-wheel:
+        description: "Update wheel for the project"
+        required: false
+        type: boolean
+      sh-runner:
+        description: "Run on shared runner"
+        required: false
+        type: boolean
+  workflow_call:
+    inputs:
+      docker-image:
+        description: "Docker image used in tests"
+        required: false
+        default: "ghcr.io/tenstorrent/tt-forge/tt-forge-slim:latest"
+        type: string
+      project:
+        description: "Project(s) to launch tests (space separated)"
+        required: false
+        type: string
+      run_id_source:
+        description: "Repo source for provided workflow run ID"
+        required: false
+        type: string
+      run_id:
+        description: "Workflow ID to use for the new version of wheel"
+        required: false
+        type: string
+      ref:
+        description: "Git ref to checkout"
+        required: false
+        type: string
+      test-filter:
+        description: "Only run tests that contains"
+        required: false
+        type: string
+      sh-runner:
+        description: "Run on shared runner"
+        required: false
+        type: boolean
 
 jobs:
-  list-runners:
+  filter-tests:
     runs-on: ubuntu-latest
+    outputs:
+      benchmark-matrix: ${{ steps.set-perf-benchmarks.outputs.perf-benchmarks }}
     steps:
-      - uses: actions/checkout@v4
-      - name: Find new offline runners in tt-forge
-        id: tt-forge
-        uses: ./.github/actions/offline-runners
-        with:
-          repo: tt-forge
-          token: ${{ secrets.GH_TOKEN }}
-      - name: Find new offline runners in tt-torch
-        id: tt-torch
-        uses: ./.github/actions/offline-runners
-        with:
-          repo: tt-torch
-          token: ${{ secrets.GH_TOKEN }}
-      - name: Find new offline runners in tt-xla
-        id: tt-xla
-        uses: ./.github/actions/offline-runners
-        with:
-          repo: tt-xla
-          token: ${{ secrets.GH_TOKEN }}
-      - name: Find new offline runners in tt-forge-fe
-        id: tt-forge-fe
-        uses: ./.github/actions/offline-runners
-        with:
-          repo: tt-forge-fe
-          token: ${{ secrets.GH_TOKEN }}
-      - name: Find new offline runners in tt-mlir
-        id: tt-mlir
-        uses: ./.github/actions/offline-runners
-        with:
-          repo: tt-mlir
-          token: ${{ secrets.GH_TOKEN }}
-      - name: Make report
-        id: report
-        shell: bash
-        run: |
-          output_file="output.txt"
-          rm -f "$output_file"
-          touch "$output_file"
-          if [ -n "${{ steps.tt-forge.outputs.new_runners }}" ]; then
-            echo "New offline runners in tt-forge: ${{ steps.tt-forge.outputs.new_runners }}" | tee -a "$output_file"
-          fi
-          if [ -n "${{ steps.tt-torch.outputs.new_runners }}" ]; then
-            echo "New offline runners in tt-torch: ${{ steps.tt-torch.outputs.new_runners }}" | tee -a "$output_file"
-          fi
-          if [ -n "${{ steps.tt-xla.outputs.new_runners }}" ]; then
-            echo "New offline runners in tt-xla: ${{ steps.tt-xla.outputs.new_runners }}" | tee -a "$output_file"
-          fi
-          if [ -n "${{ steps.tt-forge-fe.outputs.new_runners }}" ]; then
-            echo "New offline runners in tt-forge-fe: ${{ steps.tt-forge-fe.outputs.new_runners }}" | tee -a "$output_file"
-          fi
-          if [ -n "${{ steps.tt-mlir.outputs.new_runners }}" ]; then
-            echo "New offline runners in tt-mlir: ${{ steps.tt-mlir.outputs.new_runners }}" | tee -a "$output_file"
-          fi
-          if [ -s "$output_file" ]; then
-            echo "send_msg={\"text\": $(cat "$output_file" | jq -Rs .)}" >> $GITHUB_OUTPUT
-            echo "## Found new offline runners" >> $GITHUB_STEP_SUMMARY
-            cat "$output_file" >> $GITHUB_STEP_SUMMARY
-          fi
-      - name: Send Slack Notification
-        uses: slackapi/slack-github-action@v1.26.0
-        if: steps.report.outputs.send_msg
-        with:
-          payload: ${{ steps.report.outputs.send_msg }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.OFFLINE_RUNNER_SLACK_WEBHOOK }}
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: 'tenstorrent/tt-forge'
+        fetch-depth: 1
+        ref: ${{ inputs.ref || github.ref }}
+    - name: Filter Matrix
+      id: set-perf-benchmarks
+      shell: bash
+      run: |
+        if [ "${{ inputs.project-filter }}" == "All" ]; then
+          project="tt-forge-fe tt-torch tt-xla"
+        else
+          project="${{ inputs.project || inputs.project-filter }}"
+        fi
+
+        filter='.[] | select(true'
+
+        if [ -n "$project" ]; then
+          pa=($project)
+          f="false"
+          for p in "${pa[@]}"; do
+            f="$f or .project == \"$p\""
+          done
+          filter="$filter and ($f)"
+        fi
+        if [ -n "${{ inputs.test-filter }}" ]; then
+          filter="$filter and (.name | contains(\"${{ inputs.test-filter }}\"))"
+        fi
+
+        matrix=$(jq -c "[${filter})]" .github/workflows/perf-bench-matrix.json)
+        echo "Matrix: $matrix"
+        if [ "$matrix" == "[]" ]; then
+          echo "Error: No matching tests found in the matrix"
+          exit 1
+        fi
+        echo "perf-benchmarks=$matrix" >> $GITHUB_OUTPUT
+
+        # Set up the summary for the job
+        echo "### Perf benchmarks inputs" >> $GITHUB_STEP_SUMMARY
+        echo "Project(s): $project" >> $GITHUB_STEP_SUMMARY
+        echo "Test filter: ${{ inputs.test-filter }}" >> $GITHUB_STEP_SUMMARY
+        echo "Run ID source: ${{ inputs.run_id_source }}" >> $GITHUB_STEP_SUMMARY
+        echo "Run ID: ${{ inputs.run_id }}" >> $GITHUB_STEP_SUMMARY
+        echo "Shared runner: ${{ inputs.sh-runner }}" >> $GITHUB_STEP_SUMMARY
+
+  run-perf-benchmarks:
+    needs: filter-tests
+    container:
+      image: ${{ inputs.sh-runner && format('harbor.ci.tenstorrent.net/{0}', inputs.docker-image) || inputs.docker-image }}
+      options: --device /dev/tenstorrent --user root
+      volumes:
+        - /dev/hugepages:/dev/hugepages
+        - /dev/hugepages-1G:/dev/hugepages-1G
+        - /etc/udev/rules.d:/etc/udev/rules.d
+        - /lib/modules:/lib/modules
+        - /opt/tt_metal_infra/provisioning/provisioning_env:/opt/tt_metal_infra/provisioning/provisioning_env
+        - /usr/local/bin:/usr/local/bin
+        - /mnt/dockercache:/mnt/dockercache
+
+    timeout-minutes: 60
+
+    # tt-torch reqs are not needed by tt-torch, but rather by benchmarking infra, should be moved elsewhere: https://github.com/tenstorrent/tt-forge/issues/177
+    strategy:
+      fail-fast: false
+      matrix:
+        build: ${{ fromJson(needs.filter-tests.outputs.benchmark-matrix) }}
+
+    runs-on: ${{ inputs.sh-runner && format('tt-beta-ubuntu-2204-{0}-large-stable', matrix.build.runs-on) || fromJson(format('["{0}", "in-service"]', matrix.build.runs-on)) }}
+
+    env:
+      # TODO: Revisit the addition of these env vars https://github.com/tenstorrent/tt-metal/issues/20161
+      TRACY_NO_INVARIANT_CHECK: 1
+      DOCKER_CACHE_ROOT: /mnt/dockercache
+
+    name: "run-perf-benchmarks ${{matrix.build.project }}-${{matrix.build.name }} (${{ inputs.sh-runner && format('{0}-shared', matrix.build.runs-on) || (matrix.build.runs-on) }}, ${{ matrix.build.bs }}, ${{ matrix.build.lp }})"
+    steps:
+
+    - uses: actions/checkout@v4
+      with:
+        repository: 'tenstorrent/tt-forge'
+        fetch-depth: 1
+        ref: ${{ inputs.ref || github.ref }}
+
+    - name: Install system and python dependencies
+      shell: bash
+      run: |
+        if [ "${{ matrix.build.project }}" == "tt-forge-fe" ]; then
+          apt-get install -y -qq --no-install-recommends sqlite3
+        fi
+        if [ -n "${{ matrix.build.libreq }}" ]; then
+          apt-get install -y -qq --no-install-recommends ${{ matrix.build.libreq }}
+        fi
+
+        source /home/forge/venv-${{ matrix.build.project }}/bin/activate
+        if [ -n "${{ matrix.build.pyreq }}" ]; then
+          pip install ${{ matrix.build.pyreq }}
+        fi
+
+    - name: Install upgraded wheel
+      if: (inputs.project && inputs.run_id) || inputs.update-wheel
+      uses: ./.github/actions/install-wheel
+      with:
+        project: ${{ matrix.build.project }}
+        run_id: ${{ inputs.run_id }}
+        run_id_source: ${{ inputs.run_id_source }}
+
+    - name: Fetch job id
+      id: fetch-job-id
+      uses: tenstorrent/tt-github-actions/.github/actions/job_id@main
+      with:
+        job_name: "run-perf-benchmarks ${{matrix.build.project }}-${{matrix.build.name }} (${{ inputs.sh-runner && format('{0}-shared', matrix.build.runs-on) || (matrix.build.runs-on) }}, ${{ matrix.build.bs }}, ${{ matrix.build.lp }})"
+
+    - name: Set reusable strings
+      id: strings
+      shell: bash
+      env:
+        JOB_ID: ${{ steps.fetch-job-id.outputs.job_id }}
+      run: |
+        echo "work-dir=$(pwd)" >> "$GITHUB_OUTPUT"
+        echo "build-output-dir=$(pwd)/build" >> "$GITHUB_OUTPUT"
+        echo "perf_report_path=$(pwd)/benchmark_reports" >> "$GITHUB_OUTPUT"
+
+    # - name: Git safe dir
+    #   run: git config --global --add safe.directory ${{ steps.strings.outputs.work-dir }}
+
+    # ttrt version (sha) should be taken from release metadata or something
+    - name: Download ttrt wheel
+      uses: dawidd6/action-download-artifact@v11
+      with:
+        workflow_conclusion: success
+        workflow: on-push.yml
+        branch: main
+        name: "(ttrt-whl|install-artifacts)-tracy"
+        name_is_regexp: true
+        repo: tenstorrent/tt-mlir
+        check_artifacts: true
+        path: ./
+
+    - name: Untar ttmlir install directory
+      shell: bash
+      run: |
+        mv install-artifacts-tracy/ install/
+        cd install
+        tar xvf artifact.tar
+        cd ..
+
+    - name: Run Perf Benchmark
+      shell: bash
+      env:
+        HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        HF_HOME: /mnt/dockercache/huggingface
+        HF_HUB_DISABLE_PROGRESS_BARS: 1
+      run: |
+        echo "Create perf report directory"
+        mkdir -p ${{ steps.strings.outputs.perf_report_path }}
+        source /home/forge/venv-${{ matrix.build.project }}/bin/activate
+
+        if [ "${{ matrix.build.project }}" == "tt-torch" ]; then
+          export TT_TORCH_SAVE_MLIR=TTIR
+        fi
+
+        echo "Run benchmark for ${{ matrix.build.project }} - ${{ matrix.build.name }}"
+        python benchmark/benchmark.py -p ${{ matrix.build.project}} -m ${{ matrix.build.name }} -bs ${{ matrix.build.bs }} -df ${{ matrix.build.df }} -lp ${{ matrix.build.lp }} -ts ${{ matrix.build.ts }} -o ${{ steps.strings.outputs.perf_report_path }}/benchmark_${{ matrix.build.project }}_e2e_${{ matrix.build.name }}_${{ matrix.build.bs }}_${{ matrix.build.lp }}_${{ steps.fetch-job-id.outputs.job_id }}.json ${{ inputs.run_id_source && format('-r {0}', inputs.run_id_source) }}
+
+        echo "Copy dumped ttir to ttir.mlir"
+        if [ "${{ matrix.build.project }}" == "tt-torch" ]; then
+          cp ./model_mlir/${{ matrix.build.name }}_ttir.mlir ttir.mlir
+        elif [ "${{ matrix.build.project }}" == "tt-forge-fe" ]; then
+          cp ~/testify/ll-sw/${{ matrix.build.dir }}/mlir_reports/ttir.mlir ttir.mlir
+        fi
+
+        if [ "${{ matrix.build.project }}" != "tt-xla" ]; then
+          echo "Dump ttir to report"
+          cp ttir.mlir ${{ steps.strings.outputs.perf_report_path }}/ttir.mlir
+        fi
+
+    # @todo: Enable TTRT perf benchmark
+    # Uncomment the following section to enable TTRT performance benchmarking, when the issue with TTRT is resolved.
+    # The issue: https://github.com/tenstorrent/tt-forge/issues/311
+    # - name: Install and run TTRT
+    #   shell: bash
+    #   run: |
+    #     python -m venv ttrt-venv
+    #     source ttrt-venv/bin/activate
+    #     apt-get install -y -qq --no-install-recommends libtbb12 libcapstone4
+    #     pip install ttrt-whl-tracy/ttrt*.whl --upgrade
+    #     pip install torch==2.3.0 --index-url https://download.pytorch.org/whl/cpu
+    #     echo "Save artifacts"
+    #     ttrt query --save-artifacts
+    #     if [ "${{ matrix.build.project }}" != "tt-torch" ]; then
+    #       chmod ugo+x ./benchmark/ttrt_perf.sh
+    #       ./benchmark/ttrt_perf.sh ${{ matrix.build.name }}.ttnn ${{ steps.strings.outputs.perf_report_path }}/benchmark_${{ matrix.build.project }}_e2e_${{ matrix.build.name }}_${{ matrix.build.bs }}_${{ matrix.build.lp }}_${{ steps.fetch-job-id.outputs.job_id }}.json
+    #     fi
+
+    - name: Upload Perf Report
+      uses: actions/upload-artifact@v4
+      if: success() || failure()
+      with:
+        name: perf-reports-${{ steps.fetch-job-id.outputs.job_id }}
+        path: ${{ steps.strings.outputs.perf_report_path }}

--- a/.github/workflows/runner-check.yml
+++ b/.github/workflows/runner-check.yml
@@ -3,12 +3,13 @@ name: Check Repository Runners
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 6 * * *' # Every day at 6am
+    - cron: '0 */4 * * *' # Every 4 hours
 
 jobs:
   list-runners:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - name: Find new offline runners in tt-forge
         id: tt-forge
         uses: ./.github/actions/offline-runners
@@ -62,7 +63,7 @@ jobs:
             echo "New offline runners in tt-mlir: ${{ steps.tt-mlir.outputs.new_runners }}" | tee -a "$output_file"
           fi
           if [ -s "$output_file" ]; then
-            echo "send_msg={\"text\": $(cat "$output_file" | jq -Rs .)" >> $GITHUB_OUTPUT
+            echo "send_msg={\"text\": $(cat "$output_file" | jq -Rs .)}" >> $GITHUB_OUTPUT
             echo "## Found new offline runners" >> $GITHUB_STEP_SUMMARY
             cat "$output_file" >> $GITHUB_STEP_SUMMARY
           fi


### PR DESCRIPTION
We saw that sometimes runner fails during GitHub update process and stay offline. It is very easy to restore its operation but it is hard to track when this happens.
This PR introduce workflow that will periodically check VM runners status in all of the Forge repos. If new offline runner is found it will report it to dev-ex slack channel.
