### PR TITLE
Renable sharding on resnet

### DIFF
--- a/benchmark/tt-forge-fe/resnet_hf.py
+++ b/benchmark/tt-forge-fe/resnet_hf.py
@@ -126,7 +126,7 @@ def test_resnet_hf(
         .set_enable_optimizer(True)
         .set_enable_fusing(True)
         .set_enable_fusing_conv2d_with_multiply_pattern(True)
-        .set_enable_memory_layout_analysis(False)
+        .set_enable_memory_layout_analysis(True)
     )
 
     # TODO: Remove this line when the issue with reinitialization is resolved.


### PR DESCRIPTION
Hang problems with conv2d constraints are fixed in metal. We can now reenable memory layout analysis ONCE this is uplifted:
https://github.com/tenstorrent/tt-mlir/pull/4373