### PR TITLE
Fix XLA perf test to no longer embed the parameters in the flatbuffer

### DIFF
--- a/benchmark/tt-xla/resnet.py
+++ b/benchmark/tt-xla/resnet.py
@@ -74,7 +74,7 @@ def test_resnet(
     input_sample = device_put(input_sample, tt_device)
 
     # Preserve the TTIR file
-    serialize_function_to_binary(framework_model.__call__, f"{model_name}.ttnn", input_sample)
+    serialize_function_to_binary(framework_model.__call__, f"{model_name}.ttnn", input_sample, params=framework_model.params)
     compiled_fwd = jax.jit(framework_model.__call__, static_argnames=["train"])
 
     # Warm up the model


### PR DESCRIPTION
The params argument was missing in the call to the serialization logic, which lead to parameters being embedded in the graph. 