### PR TITLE
Add llama 3.2 1B decode with cache update on host to benchmark tests.

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -1,5 +1,6 @@
 [
-  { "runs-on": "n150", "project": "tt-forge-fe", "name": "llama",             "dir": "LlamaModel",                   "bs": 1,  "lp": 32, "df": "float32",  "ts": "na",             "libreq": "libgl1-mesa-glx libglib2.0-0" },
+  { "runs-on": "n150", "project": "tt-forge-fe", "name": "llama_prefill",             "dir": "LlamaModel",                   "bs": 1,  "lp": 32, "df": "bfloat16",  "ts": "na",             "libreq": "libgl1-mesa-glx libglib2.0-0" },
+  { "runs-on": "n150", "project": "tt-forge-fe", "name": "llama_decode",             "dir": "LlamaModelDecode",                   "bs": 1,  "lp": 32, "df": "bfloat16",  "ts": "na",             "libreq": "libgl1-mesa-glx libglib2.0-0" },
   { "runs-on": "n150", "project": "tt-forge-fe", "name": "mnist_linear",      "dir": "MNISTLinear",                  "bs": 32, "lp": 32, "df": "float32",  "ts": "na" },
   { "runs-on": "n150", "project": "tt-forge-fe", "name": "resnet_hf",         "dir": "ResNetForImageClassification", "bs": 8,  "lp": 32, "df": "bfloat16", "ts": "classification", "libreq": "libgl1-mesa-glx libglib2.0-0" },
   { "runs-on": "n150", "project": "tt-forge-fe", "name": "mobilenetv2_basic", "dir": "MobileNetv2Basic",             "bs": 8,  "lp": 32, "df": "bfloat16", "ts": "classification", "libreq": "libgl1-mesa-glx libglib2.0-0" },

--- a/benchmark/run_benchmark_wh.sh
+++ b/benchmark/run_benchmark_wh.sh
@@ -27,28 +27,31 @@
 python benchmark/benchmark.py -p tt-forge-fe -m mnist_linear -bs 32 -lp 32 -o forge-benchmark-e2e-tt-forge-fe-mnist-linear.json
 
 # Resnet HF
-python benchmark/benchmark.py -p tt-forge-fe -m resnet_hf -ts classification -bs 8 -df bfloat16 -lp 32 -o orge-benchmark-e2e-tt-forge-fe-resnet50_hf.json
+python benchmark/benchmark.py -p tt-forge-fe -m resnet_hf -ts classification -bs 8 -df bfloat16 -lp 32 -o forge-benchmark-e2e-tt-forge-fe-resnet50_hf.json
 
 # EfficientNet Timm
-python benchmark/benchmark.py -p tt-forge-fe -m efficientnet_timm -ts classification -bs 6 -df bfloat16 -lp 32 -o orge-benchmark-e2e-tt-forge-fe-efficientnet_timm.json
+python benchmark/benchmark.py -p tt-forge-fe -m efficientnet_timm -ts classification -bs 6 -df bfloat16 -lp 32 -o forge-benchmark-e2e-tt-forge-fe-efficientnet_timm.json
 
 # Llama
-python benchmark/benchmark.py -p tt-forge-fe -m llama -bs 1 -df float32 -lp 32 -o orge-benchmark-e2e-tt-forge-fe-llama.json
+python benchmark/benchmark.py -p tt-forge-fe -m llama_prefill -bs 1 -df bfloat16 -lp 32 -o forge-benchmark-e2e-tt-forge-fe-llama.json
+
+# Llama decode
+python benchmark/benchmark.py -p tt-forge-fe -m llama_decode -bs 1 -df bfloat16 -lp 32 -o forge-benchmark-e2e-tt-forge-fe-llama_decode.json
 
 # MobileNetV2 Basic
-python benchmark/benchmark.py -p tt-forge-fe -m mobilenetv2_basic -ts classification -bs 8 -df bfloat16 -lp 32 -o orge-benchmark-e2e-tt-forge-fe-mobilenetv2_basic.json
+python benchmark/benchmark.py -p tt-forge-fe -m mobilenetv2_basic -ts classification -bs 8 -df bfloat16 -lp 32 -o forge-benchmark-e2e-tt-forge-fe-mobilenetv2_basic.json
 
 # Segformer Classification
 python benchmark/benchmark.py -p tt-forge-fe -m segformer -bs 1 -df bfloat16 -lp 32 -o forge-benchmark-e2e-tt-forge-fe-segformer.json
 
 # ViT Base
-python benchmark/benchmark.py -p tt-forge-fe -m vit -ts classification -bs 1 -df bfloat16 -lp 32 -o orge-benchmark-e2e-tt-forge-fe-vit_base.json
+python benchmark/benchmark.py -p tt-forge-fe -m vit -ts classification -bs 1 -df bfloat16 -lp 32 -o forge-benchmark-e2e-tt-forge-fe-vit_base.json
 
 # Vovnet OSMR
 python benchmark/benchmark.py -p tt-forge-fe -m vovnet -ts classification -bs 8 -df bfloat16 -lp 32 -o forge-benchmark-e2e-tt-forge-fe-vovnet_osmr.json
 
 # Yolo4
-python benchmark/benchmark.py -p tt-forge-fe -m yolo_v4 -ts na -bs 1 -df bfloat16 -lp 32 -o orge-benchmark-e2e-tt-forge-fe-yolo_v4.json
+python benchmark/benchmark.py -p tt-forge-fe -m yolo_v4 -ts na -bs 1 -df bfloat16 -lp 32 -o forge-benchmark-e2e-tt-forge-fe-yolo_v4.json
 
 # Yolo8
 python benchmark/benchmark.py -p tt-forge-fe -m yolo_v8 -ts na -bs 1 -df bfloat16 -lp 32 -o forge-benchmark-e2e-tt-forge-fe-yolo_v8.json
@@ -57,10 +60,10 @@ python benchmark/benchmark.py -p tt-forge-fe -m yolo_v8 -ts na -bs 1 -df bfloat1
 python benchmark/benchmark.py -p tt-forge-fe -m yolo_v9 -ts na -bs 1 -df bfloat16 -lp 32 -o forge-benchmark-e2e-tt-forge-fe-yolo_v9.json
 
 # Yolo10
-python benchmark/benchmark.py -p tt-forge-fe -m yolo_v10 -ts na -bs 1 -df bfloat16 -lp 32 -o orge-benchmark-e2e-tt-forge-fe-yolo_v10.json
+python benchmark/benchmark.py -p tt-forge-fe -m yolo_v10 -ts na -bs 1 -df bfloat16 -lp 32 -o forge-benchmark-e2e-tt-forge-fe-yolo_v10.json
 
 # Unet
-python benchmark/benchmark.py -p tt-forge-fe -m unet -ts na -bs 1 -df bfloat16 -lp 32 -o orge-benchmark-e2e-tt-forge-fe-unet.json
+python benchmark/benchmark.py -p tt-forge-fe -m unet -ts na -bs 1 -df bfloat16 -lp 32 -o forge-benchmark-e2e-tt-forge-fe-unet.json
 
 # ------------------------------------------------------- #
 # TT-Torch Compiler

--- a/benchmark/tt-forge-fe/llama_decode.py
+++ b/benchmark/tt-forge-fe/llama_decode.py
@@ -1,0 +1,346 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+# Built-in modules
+import pytest
+import time
+import socket
+import subprocess
+import json
+import random
+import os
+from datetime import datetime
+
+# Third-party modules
+import torch
+from transformers import LlamaTokenizer
+from transformers.cache_utils import DynamicCache
+from transformers.modeling_attn_mask_utils import _prepare_4d_causal_attention_mask
+
+# Forge modules
+import forge
+from forge._C.runtime.experimental import configure_devices, DeviceSettings
+from forge.config import CompilerConfig
+from forge.verify.compare import compare_with_golden
+from forge._C import DataFormat
+
+# Utils
+from utils import load_model
+
+
+class LlamaModelWrapper(torch.nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+        self.embed_tokens = model.model.embed_tokens
+
+    def forward(self, input_ids, attention_mask=None, position_ids=None, *past_key_values):
+
+        inputs_embeds = self.embed_tokens(input_ids)
+
+        if past_key_values:
+            past_key_values = [past_key_values[i : i + 2] for i in range(0, len(past_key_values), 2)]
+        else:
+            past_key_values = None
+
+        if past_key_values is not None:
+            past_key_values = DynamicCache.from_legacy_cache(past_key_values)
+            past_key_values_length = past_key_values.get_seq_length()
+        else:
+            past_key_values_length = 0
+
+        causal_attention_mask = _prepare_4d_causal_attention_mask(
+            attention_mask, input_ids.shape, inputs_embeds, past_key_values_length
+        )
+
+        outputs = self.model(
+            input_ids=input_ids,
+            attention_mask=causal_attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            use_cache=True,
+        )
+
+        print("type of outputs: ", type(outputs))
+        logits = outputs.logits
+        past_key_values = outputs.past_key_values
+
+        # Flatten past_key_values for output
+        flattened_past_key_values = []
+        for layer_past in past_key_values:
+            flattened_past_key_values.extend(layer_past)
+
+        return [logits] + flattened_past_key_values
+
+
+def calculate_attention_mask_and_postion_ids(
+    padded_past_key_values_seq_length, non_padding_past_key_values_seq_length, input_seq_length
+):
+
+    # Calculate attention mask
+    attention_mask = torch.zeros(padded_past_key_values_seq_length + input_seq_length, dtype=torch.long)
+    attention_mask[:non_padding_past_key_values_seq_length] = 1
+    attention_mask[-1] = 1
+    attention_mask = attention_mask.unsqueeze(0)
+
+    # Calculate position ids
+    position_ids = torch.arange(
+        non_padding_past_key_values_seq_length,
+        input_seq_length + non_padding_past_key_values_seq_length,
+        dtype=torch.long,
+    )
+    position_ids = position_ids.unsqueeze(0)
+
+    return attention_mask, position_ids
+
+
+# Common constants
+
+# Model path
+MODEL_PATH = ["meta-llama/Llama-3.2-1B", "openlm-research/open_llama_3b"]
+
+# Data format configurations
+DATA_FORMAT = [
+    "bfloat16",
+]
+
+# Loop count configurations
+LOOP_COUNT = [1, 2, 4, 8, 16, 32]
+
+
+@pytest.mark.parametrize("loop_count", LOOP_COUNT, ids=[f"loop_count={item}" for item in LOOP_COUNT])
+@pytest.mark.parametrize("data_format", DATA_FORMAT, ids=[f"data_format={item}" for item in DATA_FORMAT])
+@pytest.mark.parametrize("model_path", MODEL_PATH, ids=["_".join(item.split("/")) for item in MODEL_PATH])
+def test_llama_decode(
+    training,
+    batch_size,
+    model_path,
+    loop_count,
+    data_format,
+    model_name,
+):
+
+    if data_format == "bfloat16":
+        torch_dtype = torch.bfloat16
+        data_format_override = DataFormat.Float16_b
+        compiler_cfg = CompilerConfig(default_df_override=data_format_override)
+    else:
+        torch_dtype = torch.float32
+        compiler_cfg = CompilerConfig()
+
+    if training:
+        pytest.skip("Training is not supported")
+
+    if batch_size > 1:
+        pytest.skip("Batch size greater than 1 is not supported")
+
+    # Load model with cache enabled
+    use_fast = False if model_path == "openlm-research/open_llama_3b" else True
+    model, tokenizer = load_model(
+        model_path,
+        use_cache=True,
+        use_fast=use_fast,
+    )
+
+    model.config.max_position_embeddings = 2048
+    max_sequence_length = model.config.max_position_embeddings
+    framework_model = LlamaModelWrapper(model)
+    framework_model = framework_model.to(torch_dtype)
+    framework_model.eval()
+
+    if model_path == "openlm-research/open_llama_3b":
+        tokenizer.pad_token_id = model.config.pad_token_id
+    elif model_path == "meta-llama/Llama-3.2-1B":
+        tokenizer.pad_token = tokenizer.eos_token
+
+    # Prepare input sentence
+    prompt = "Q: What is the largest animal?\nA:"
+    inputs = tokenizer(prompt, return_tensors="pt")
+
+    # Run Prefill on CPU with cache to get the initial logits and past key-values
+    prefill_output = framework_model(input_ids=inputs.input_ids, attention_mask=inputs.attention_mask)
+    next_token_logits = prefill_output[0][:, -1, :]
+    next_token = torch.argmax(next_token_logits, dim=-1)
+
+    generated_tokens = inputs.input_ids
+    generated_tokens = torch.cat([generated_tokens, next_token.unsqueeze(0)], dim=-1)
+
+    model_inputs = [next_token.unsqueeze(0)]
+    model_inputs.extend(prefill_output[1:])
+
+    # Zero Pad past key values in key_value_seq_len(i.e -2) dimension
+    max_new_tokens = loop_count  # Use loop_count as max_new_tokens for benchmarking
+    non_padding_seq_length = prefill_output[1].shape[-2]
+    for idx, past_key_or_values_states in enumerate(model_inputs[1:]):
+        model_inputs[idx + 1] = torch.cat(
+            [
+                past_key_or_values_states,
+                torch.zeros(
+                    past_key_or_values_states.shape[-4],
+                    past_key_or_values_states.shape[-3],
+                    max_sequence_length - non_padding_seq_length,
+                    past_key_or_values_states.shape[-1],
+                ).to(past_key_or_values_states.dtype),
+            ],
+            dim=-2,
+        )
+
+    # Calculate attention mask and postion_ids
+    padded_past_key_values_seq_length = model_inputs[1].shape[-2]
+    input_seq_length = model_inputs[0].shape[-1]
+    attention_mask, position_ids = calculate_attention_mask_and_postion_ids(
+        padded_past_key_values_seq_length, non_padding_seq_length, input_seq_length
+    )
+
+    # Compile the model
+    module_name = "LlamaModelDecode"
+    compiled_model = forge.compile(
+        framework_model,
+        sample_inputs=[model_inputs[0], attention_mask, position_ids, *model_inputs[1:]],
+        module_name=module_name,
+        compiler_cfg=compiler_cfg,
+    )
+    compiled_model.save(f"{model_name}.ttnn")
+
+    # Enable program cache on all devices
+    settings = DeviceSettings()
+    settings.enable_program_cache = True
+    configure_devices(device_settings=settings)
+
+    # Run decode stage on TT device and generate tokens
+    start = time.time()
+    tokens_generated = 0
+
+    for max_new_tokens_idx in range(max_new_tokens):
+        non_padding_past_key_values_seq_length = non_padding_seq_length + max_new_tokens_idx
+        padded_past_key_values_seq_length = model_inputs[1].shape[-2]
+        input_seq_length = model_inputs[0].shape[-1]
+        attention_mask, position_ids = calculate_attention_mask_and_postion_ids(
+            padded_past_key_values_seq_length, non_padding_past_key_values_seq_length, input_seq_length
+        )
+
+        tt_inputs = [model_inputs[0], attention_mask, position_ids, *model_inputs[1:]]
+        tt_output = compiled_model(*tt_inputs)
+
+        logits = tt_output[0]
+        past_key_values = tt_output[1:]
+
+        next_token_logits = logits[:, -1, :]
+        next_token = torch.argmax(next_token_logits, dim=-1)
+
+        if next_token == tokenizer.eos_token_id:
+            break
+
+        model_inputs = [next_token.unsqueeze(0)]
+        model_inputs.extend(past_key_values)
+
+        # Move generated token states to padding position
+        for idx in range(len(model_inputs[1:])):
+            model_inputs[idx + 1][:, :, non_padding_past_key_values_seq_length, :] = model_inputs[idx + 1][:, :, -1, :]
+            model_inputs[idx + 1] = model_inputs[idx + 1][:, :, :-1, :].contiguous()
+
+        generated_tokens = torch.cat([generated_tokens, next_token.unsqueeze(0)], dim=-1)
+        tokens_generated += 1
+
+    end = time.time()
+
+    # Calculate metrics
+    date = datetime.now().strftime("%d-%m-%Y")
+    machine_name = socket.gethostname()
+    input_size = len(inputs.input_ids[0])
+    total_time = end - start
+    total_tokens = tokens_generated
+
+    tokens_per_sec = total_tokens / total_time if total_time > 0 else 0
+    full_model_name = "Llama Decode"
+    model_type = "Text Generation, Random Text Data"
+    dataset_name = "Llama, Random Data"
+    num_layers = -1
+    batch_size = 1
+
+    input_sequence_length = len(inputs.input_ids[0])
+    output_sequence_length = tokens_generated
+
+    generated_text = tokenizer.decode(generated_tokens[0], skip_special_tokens=True)
+
+    print("====================================================================")
+    print("| Llama Decode Benchmark Results:                                  |")
+    print("--------------------------------------------------------------------")
+    print(f"| Model: {full_model_name}")
+    print(f"| Model type: {model_type}")
+    print(f"| Dataset name: {dataset_name}")
+    print(f"| Date: {date}")
+    print(f"| Machine name: {machine_name}")
+    print(f"| Total execution time: {total_time}")
+    print(f"| Total tokens generated: {total_tokens}")
+    print(f"| Token per second: {tokens_per_sec}")
+    print(f"| Input size: {input_size}")
+    print(f"| Generated text: {generated_text}")
+    print("====================================================================")
+
+    result = {
+        "model": full_model_name,
+        "model_type": model_type,
+        "run_type": f"{'_'.join(full_model_name.split())}_{input_size}_{tokens_generated}",
+        "config": {"model_size": "small"},
+        "num_layers": num_layers,
+        "batch_size": batch_size,
+        "precision": data_format,
+        "dataset_name": dataset_name,
+        "profile_name": "",
+        "input_sequence_length": input_sequence_length,
+        "output_sequence_length": output_sequence_length,
+        "perf_analysis": False,
+        "training": training,
+        "measurements": [
+            {
+                "iteration": 1,
+                "step_name": full_model_name,
+                "step_warm_up_num_iterations": 0,
+                "measurement_name": "total_tokens",
+                "value": total_tokens,
+                "target": -1,
+                "device_power": -1.0,
+                "device_temperature": -1.0,
+            },
+            {
+                "iteration": 1,
+                "step_name": full_model_name,
+                "step_warm_up_num_iterations": 0,
+                "measurement_name": "total_time",
+                "value": total_time,
+                "target": -1,
+                "device_power": -1.0,
+                "device_temperature": -1.0,
+            },
+        ],
+        "device_info": {
+            "device_name": "",
+            "galaxy": False,
+            "arch": "",
+            "chips": 1,
+        },
+        "device_ip": None,
+    }
+
+    return result
+
+
+def benchmark(config: dict):
+
+    training = config["training"]
+    batch_size = config["batch_size"]
+    model_path = MODEL_PATH[0]
+    loop_count = config["loop_count"]
+    model_name = config["model"]
+    data_format = config["data_format"]
+
+    return test_llama_decode(
+        training=training,
+        batch_size=batch_size,
+        model_path=model_path,
+        loop_count=loop_count,
+        model_name=model_name,
+        data_format=data_format,
+    )

--- a/benchmark/tt-forge-fe/utils.py
+++ b/benchmark/tt-forge-fe/utils.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+from transformers import LlamaConfig, LlamaForCausalLM, AutoTokenizer
+from peft import LoraConfig, get_peft_model
+
+
+def load_model(model_path="openlm-research/open_llama_3b", **kwargs):
+    # Default config values
+    config = LlamaConfig.from_pretrained(model_path)
+
+    # Use defaults or values from kwargs
+    config.use_cache = kwargs.get("use_cache", False)
+    config.output_attentions = kwargs.get("output_attentions", False)
+    config.output_hidden_states = kwargs.get("output_hidden_states", False)
+    if "num_hidden_layers" in kwargs and kwargs["num_hidden_layers"] is not None:
+        config.num_hidden_layers = kwargs["num_hidden_layers"]
+
+    # Load the model
+    framework_model = LlamaForCausalLM.from_pretrained(model_path, config=config)
+    framework_model.eval()
+
+    use_lora = kwargs.get("use_lora", False)
+    if use_lora:
+        lora_r = kwargs.get("lora_r", 4)
+        lora_alpha = kwargs.get("lora_alpha", 8)
+        # Applying LoRA to the last half of all layers due to memory constraints, this should be configurable
+        ltt = range(framework_model.config.num_hidden_layers // 2, framework_model.config.num_hidden_layers)
+        lora_config = LoraConfig(r=lora_r, lora_alpha=lora_alpha, task_type="CAUSAL_LM", layers_to_transform=ltt)
+        framework_model = get_peft_model(framework_model, lora_config)
+
+    # Using AutoTokenizer for default tokenizers for both openllama and llama 3.2
+    use_fast = kwargs.get("use_fast", True)
+    tokenizer = AutoTokenizer.from_pretrained(model_path, use_fast=use_fast)
+
+    return framework_model, tokenizer


### PR DESCRIPTION
- Add llama 3.2 1B decode with cache update on host to benchmark tests.
- Rename llama.py to llama_prefill.py and use bfloat16 in prefill instead of f32.