### PR TITLE
Automate version bump of releases

### DIFF
--- a/.github/actions/create-rc-branch/action.yml
+++ b/.github/actions/create-rc-branch/action.yml
@@ -3,8 +3,8 @@
 name: "Create RC branch"
 description: "Create RC branch"
 inputs:
-  repo:
-    description: "Repo name"
+  repo_full:
+    description: "Repo full name"
     required: true
   draft:
     description: "Draft release"
@@ -39,12 +39,6 @@ inputs:
     description: "Set that workflow result is job result"
     default: ""
     required: false
-  major_version:
-    description: "Major version"
-    required: false
-  minor_version:
-    description: "Minor version"
-    required: false
   override_release_fact_workflow:
     description: "Ignore release facts workflow"
     required: false
@@ -71,6 +65,13 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Set Release Facts
+      id: set-release-facts
+      uses: ./.github/actions/set-release-facts
+      with:
+        repo: ${{ inputs.repo_full }}
+        release_type: ${{ inputs.release_type }}
+        draft: ${{ inputs.draft || false }}
 
     - name: Create new branch and tag
       id: create-rc-branch
@@ -78,8 +79,10 @@ runs:
       run: |
         # Get the latest release branch and create a new semver bumped release branch in frontend repos
 
+        ./.github/scripts/get_version.sh "${{ steps.set-release-facts.outputs.version_repo_ref }}"
+        source .rendered_version
         branch_prefix="release"
-        tag_prefix="${{ inputs.major_version }}.${{ inputs.minor_version }}.0"
+        tag_prefix="${MAJOR}.${MINOR}.0"
 
         if [ "${{ inputs.draft }}" == "true" ]; then
             branch_prefix="draft-${{ inputs.draft_slug_name }}-release"
@@ -87,7 +90,7 @@ runs:
         fi
 
         tag_name="${tag_prefix}rc1"
-        branch_name="${branch_prefix}-${{ inputs.major_version }}.${{ inputs.minor_version }}"
+        branch_name="${branch_prefix}-${MAJOR}.${MINOR}"
 
         echo "branch_name=$branch_name"
         echo "tag_name=$tag_name"
@@ -101,7 +104,7 @@ runs:
       env:
         GH_TOKEN: ${{ github.token }}
       with:
-        repo: ${{ inputs.repo }}
+        repo: ${{ inputs.repo_full }}
         branch: ${{ inputs.branch || 'main' }}
         workflow: ${{ inputs.workflow || steps.set-release-facts.outputs.workflow }}
         workflow_allow_failed: ${{ inputs.workflow_allow_failed }}
@@ -114,7 +117,7 @@ runs:
       uses: actions/checkout@v4
       if: ${{ inputs.draft == 'false' }}
       with:
-        repository: ${{ inputs.repo }}
+        repository: ${{ inputs.repo_full }}
         token: ${{ inputs.GH_TOKEN }}
         ref: ${{ steps.find_workflow.outputs.run-commit-sha }}
         fetch-depth: 0
@@ -137,7 +140,7 @@ runs:
             git checkout -b $branch ${{ steps.find_workflow.outputs.run-commit-sha }}
             git push origin $branch
         else
-            echo "Release branch: $branch already exists. If you need to recreate a new branch for RC release, please delete the existing branch: ${branch}, the tag: ${tag_name}, and the GH release: ${tag_name} on repo: ${{ inputs.repo }}. Then start this process again"
+            echo "Release branch: $branch already exists. If you need to recreate a new branch for RC release, please delete the existing branch: ${branch}, the tag: ${tag_name}, and the GH release: ${tag_name} on repo: ${{ inputs.repo_full }}. Then start this process again"
             branch_exists=true
         fi
 

--- a/.github/actions/set-release-facts/action.yaml
+++ b/.github/actions/set-release-facts/action.yaml
@@ -72,12 +72,6 @@ outputs:
   build_release_latest_branch_commit:
     description: "Build release latest branch commit"
     value: ${{ steps.set-manifest.outputs.build_release_latest_branch_commit }}
-  major_version:
-    description: "Major version"
-    value: ${{ steps.set-manifest.outputs.major_version }}
-  minor_version:
-    description: "Minor version"
-    value: ${{ steps.set-manifest.outputs.minor_version }}
   prerelease:
     description: "Prerelease release"
     value: ${{ steps.set-manifest.outputs.prerelease }}
@@ -114,6 +108,15 @@ outputs:
   test_demo_wait:
     description: "Test demo wait"
     value: ${{ steps.set-manifest.outputs.test_demo_wait }}
+  version_repo_ref:
+    description: "New nightly version repo ref"
+    value: ${{ steps.set-manifest.outputs.version_repo_ref }}
+  test_basic_runner_filter:
+    description: "Test basic runner filter"
+    value: ${{ steps.set-manifest.outputs.test_basic_runner_filter }}
+  test_basic_project_filter:
+    description: "Test basic project filter"
+    value: ${{ steps.set-manifest.outputs.test_basic_project_filter }}
 
 
 runs:
@@ -125,7 +128,6 @@ runs:
       run: |
         # Set release facts based on repo
         set -e
-        source .version
 
         # All Repo Defaults
 
@@ -143,14 +145,18 @@ runs:
         draft="${{ inputs.draft }}"
         event_name="${{ github.event_name }}"
         make_latest="false"
-        major_version=$MAJOR
-        minor_version=$MINOR
         ignore_artifacts="false"
         skip_model_compatible_table="false"
         skip_docker_build="false"
         git_log_fail_on_error="true"
         test_demo_filter=""
         test_demo_wait="false"
+        # Used to reference different repo's stable version from a in the nightly version workflow. Useful when a repo only has a nightly release and no stable release.
+        version_repo_ref="${repo_full}"
+        # Used to filter runner type in the basic tests workflow.
+        test_basic_runner_filter="All"
+        # Used to filter project type in the basic tests workflow.
+        test_basic_project_filter="All"
 
         # Tag & Release Defaults
 
@@ -161,14 +167,12 @@ runs:
           prerelease="false"
           make_latest="true"
         elif [[ "${{ inputs.release_type }}" == "nightly" ]]; then
-          new_version_tag="${VERSION}.dev$(date +"%Y%m%d")"
           workflow_allow_failed="true"
           build_release_find_workflow_branch="main"
         fi
 
         gh_new_version_tag="${new_version_tag}"
         build_release_tag="${new_version_tag}"
-
 
         # Repo Specific Defaults
 
@@ -200,6 +204,7 @@ runs:
             pip_wheel_names="ttmlir"
             skip_model_compatible_table="true"
             skip_docker_build="true"
+            version_repo_ref="tenstorrent/tt-forge-fe"
         elif [[ "${{ inputs.repo }}" =~ "tt-xla" ]]; then
             workflow="On nightly"
             if [[ "${{ inputs.release_type }}" == "nightly" ]]; then
@@ -215,8 +220,8 @@ runs:
             skip_wheel_install="true"
             skip_model_compatible_table="true"
             skip_docker_build="true"
+            version_repo_ref="tenstorrent/tt-forge-fe"
         fi
-
 
         # Testing Overrides
 
@@ -228,6 +233,15 @@ runs:
             # Wait for the demo test to complete only for draft releases and run only one test
             test_demo_filter="opt_125m"
             test_demo_wait="true"
+
+            # Use only the n150 runner for draft releases since this is the most available runner in CIv2.
+            test_basic_runner_filter="tt-ubuntu-2204-n150-stable"
+
+            # Skip is used to skip the project filter in the basic tests workflow. Only allow xla to be tested to reduce CIv2 usage.
+            test_basic_project_filter="skip"
+            if [[ "$repo_short" == "tt-xla" ]]; then
+                test_basic_project_filter="tt-xla"
+            fi
 
             # null out the commit to so integration testing can pick up the arfiacts from the repo.
             # This is because this commit belongs to the tt-forge repo not where the artifacts are stored.
@@ -282,8 +296,6 @@ runs:
         echo "build_release_tag=$build_release_tag"
         echo "build_release_find_workflow_branch=$build_release_find_workflow_branch"
         echo "build_release_latest_branch_commit=$build_release_latest_branch_commit"
-        echo "major_version=$major_version"
-        echo "minor_version=$minor_version"
         echo "prerelease=$prerelease"
         echo "draft=$draft"
         echo "make_latest=$make_latest"
@@ -293,6 +305,9 @@ runs:
         echo "git_log_fail_on_error=$git_log_fail_on_error"
         echo "test_demo_filter=$test_demo_filter"
         echo "test_demo_wait=$test_demo_wait"
+        echo "version_repo_ref=$version_repo_ref"
+        echo "test_basic_runner_filter=$test_basic_runner_filter"
+        echo "test_basic_project_filter=$test_basic_project_filter"
 
         # Set outputs
         echo "workflow=$workflow" >> $GITHUB_OUTPUT
@@ -313,8 +328,6 @@ runs:
         echo "build_release_tag=$build_release_tag" >> $GITHUB_OUTPUT
         echo "build_release_find_workflow_branch=$build_release_find_workflow_branch" >> $GITHUB_OUTPUT
         echo "workflow_allow_failed=$workflow_allow_failed" >> $GITHUB_OUTPUT
-        echo "major_version=$major_version" >> $GITHUB_OUTPUT
-        echo "minor_version=$minor_version" >> $GITHUB_OUTPUT
         echo "prerelease=$prerelease" >> $GITHUB_OUTPUT
         echo "draft=$draft" >> $GITHUB_OUTPUT
         echo "build_release_find_workflow_branch=$build_release_find_workflow_branch" >> $GITHUB_OUTPUT
@@ -326,3 +339,6 @@ runs:
         echo "git_log_fail_on_error=$git_log_fail_on_error" >> $GITHUB_OUTPUT
         echo "test_demo_filter=$test_demo_filter" >> $GITHUB_OUTPUT
         echo "test_demo_wait=$test_demo_wait" >> $GITHUB_OUTPUT
+        echo "version_repo_ref=$version_repo_ref" >> $GITHUB_OUTPUT
+        echo "test_basic_runner_filter=$test_basic_runner_filter" >> $GITHUB_OUTPUT
+        echo "test_basic_project_filter=$test_basic_project_filter" >> $GITHUB_OUTPUT

--- a/.github/actions/wait-workflow/action.yml
+++ b/.github/actions/wait-workflow/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: "Wait only for run url"
     required: false
     default: false
+  poll_interval:
+    description: "Interval in seconds to poll for workflow run"
+    required: false
+    default: 10
 
 outputs:
   run_head_sha:
@@ -89,7 +93,7 @@ runs:
         if [[ "${{ inputs.wait_for_run_url }}" == "true" ]]; then
           echo "Workflow run url: $run_url"
         else
-          gh run watch $match_run_id
+          gh run watch --interval ${{ inputs.poll_interval }} $match_run_id
           echo "Workflow run completed"
           echo "Workflow run url: $run_url"
           run_conclusion=$(gh run view $match_run_id --json conclusion | jq -rc '.conclusion')

--- a/.github/scripts/get_version.sh
+++ b/.github/scripts/get_version.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Script to get the latest released version from GitHub repo to determine the next version to use.
+
+set -e  # Exit on any error
+
+# Function to get the latest release version from GitHub
+get_latest_github_release() {
+    local repo="${1:-}"
+
+    echo "Fetching latest release for repository: $repo" >&2
+
+    # Get the latest release tag
+    latest_version=$(gh release view --repo "$repo" --json tagName -q .tagName 2>/dev/null || echo "")
+
+    if [[ -z "$latest_version" ]]; then
+        echo "Error: No releases found for repository $repo" >&2
+        exit 1
+    fi
+
+    echo "Latest release found: $latest_version" >&2
+    echo "$latest_version"
+}
+
+# Function to parse version string and extract MAJOR.MINOR.PATCH
+parse_version() {
+    local version="$1"
+
+    # Extract MAJOR.MINOR.PATCH using regex
+    if [[ $version =~ ^([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+        API_MAJOR="${BASH_REMATCH[1]}"
+        API_MINOR="${BASH_REMATCH[2]}"
+        # PATCH is set to 0 since bumps for that are handled in the get-release-branch workflow
+        API_PATCH="0"
+        echo "Parsed version: MAJOR=$API_MAJOR, MINOR=$API_MINOR, PATCH=$API_PATCH" >&2
+    else
+        echo "Error: Invalid version format: $version" >&2
+        exit 1
+    fi
+}
+
+# Function to bump the MINOR version
+bump_minor_version() {
+    MINOR=$((MINOR + 1))
+    echo "Bumped MINOR version: MAJOR=$MAJOR, MINOR=$MINOR, PATCH=$PATCH" >&2
+}
+
+# Function to render the .rendered_version file
+render_version_file() {
+    local version_file=".rendered_version"
+
+    echo "Updating $version_file..." >&2
+
+    cat > "$version_file" << EOF
+MAJOR=$MAJOR
+MINOR=$MINOR
+PATCH=$PATCH
+VERSION="\$MAJOR.\$MINOR.\$PATCH"
+EOF
+
+    echo "Updated $version_file with MAJOR=$MAJOR, MINOR=$MINOR, PATCH=$PATCH" >&2
+}
+
+# Main execution
+main() {
+    local repo="$1"
+
+    # Get latest release version from GitHub repo
+    latest_version=$(get_latest_github_release "$repo")
+
+    # Parse the version from API
+    parse_version "$latest_version"
+
+    # Compare MAJOR versions to determine if we need to use the MAJOR from the .version file or the API version.
+    # Used when needed to bump to a new major version.
+    source .version
+    VERSION_FILE_MAJOR=$MAJOR
+
+    if [[ $API_MAJOR -lt $VERSION_FILE_MAJOR ]]; then
+        echo "API MAJOR ($API_MAJOR) > current MAJOR ($VERSION_FILE_MAJOR), using .version file" >&2
+        MAJOR=$VERSION_FILE_MAJOR
+        MINOR=0
+        PATCH=0
+    else
+        echo "Using API version and bumping MINOR" >&2
+        MAJOR=$API_MAJOR
+        MINOR=$API_MINOR
+        PATCH=$API_PATCH
+        # Bump the MINOR version
+        bump_minor_version
+    fi
+
+    # Create the .rendered_version file
+    render_version_file
+
+    # Output the final version
+    VERSION="$MAJOR.$MINOR.$PATCH"
+    echo "Created version: $VERSION"
+}
+
+# Run main function with all arguments
+main "$@"

--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -22,6 +22,16 @@ on:
           - tt-forge-fe
           - tt-torch
           - tt-xla
+          - skip
+          - All
+        default: All
+      runner-filter:
+        description: "Runner filter"
+        required: false
+        type: choice
+        options:
+          - tt-ubuntu-2204-n150-stable
+          - tt-ubuntu-2204-p150b-stable
           - All
         default: All
 
@@ -33,10 +43,11 @@ on:
         type: string
 
 jobs:
-  build_matrix:
+  set-matrix:
     runs-on: ubuntu-latest
     outputs:
       json_matrix: ${{ steps.set-matrix.outputs.json_matrix }}
+      matrix_skip: ${{ steps.set-matrix.outputs.matrix_skip }}
     steps:
       - name: Set matrix
         id: set-matrix
@@ -45,8 +56,17 @@ jobs:
           json_matrix="[]"
           frontends="tt-forge-fe tt-torch tt-xla"
           runs_on="tt-ubuntu-2204-n150-stable tt-ubuntu-2204-p150b-stable"
+          matrix_skip="false"
 
-          if [ -n "${{ inputs.project-filter }}" ]; then
+          if [ "${{ inputs.project-filter }}" == "skip" ]; then
+            matrix_skip="true"
+          fi
+
+          if [ "${{ inputs.runner-filter }}" != "All" ]; then
+            runs_on="${{ inputs.runner-filter }}"
+          fi
+
+          if [ "${{ inputs.project-filter }}" != "All" ]; then
             frontends="${{ inputs.project-filter }}"
           fi
 
@@ -60,16 +80,19 @@ jobs:
           done
 
           echo "json_matrix=$json_matrix"
-          echo "json_matrix=$json_matrix" >> $GITHUB_OUTPUT
+          echo "matrix_skip=$matrix_skip"
 
+          echo "json_matrix=$json_matrix" >> $GITHUB_OUTPUT
+          echo "matrix_skip=$matrix_skip" >> $GITHUB_OUTPUT
 
   basic-test:
+    if: ${{ needs.set-matrix.outputs.matrix_skip == 'false' }}
     name: Basic test ${{ matrix.frontend }} on ${{ matrix.run_on }}
-    needs: build_matrix
+    needs: set-matrix
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJson(needs.build_matrix.outputs.json_matrix) }}
+        include: ${{ fromJson(needs.set-matrix.outputs.json_matrix) }}
 
     runs-on: ${{ matrix.run_on }}
     container:

--- a/.github/workflows/create-version-branches.yml
+++ b/.github/workflows/create-version-branches.yml
@@ -85,6 +85,8 @@ jobs:
       repo_short: ${{ steps.set-release-facts.outputs.repo_short }}
       branch_exists: ${{ steps.create-rc-branch.outputs.branch_exists }}
     runs-on: ubuntu-latest
+    env:
+        GH_TOKEN: ${{ github.token }}
     steps:
     - uses: actions/checkout@v4
       with:
@@ -100,7 +102,7 @@ jobs:
       id: create-rc-branch
       uses: ./.github/actions/create-rc-branch
       with:
-        repo: ${{ steps.set-release-facts.outputs.draft == 'true' && 'tenstorrent/tt-forge' || steps.set-release-facts.outputs.repo_full }}
+        repo_full: ${{ steps.set-release-facts.outputs.draft == 'true' && 'tenstorrent/tt-forge' || steps.set-release-facts.outputs.repo_full }}
         draft: ${{steps.set-release-facts.outputs.draft == 'true' || false }}
         workflow_allow_failed: ${{ inputs.workflow_allow_failed }}
         GH_TOKEN: ${{ secrets.TT_FORGE_RELEASER }}
@@ -109,8 +111,6 @@ jobs:
         branch: ${{ inputs.branch || github.head_ref }}
         ignore_artifacts: ${{ inputs.ignore_artifacts || false }}
         workflow_result_in_job: ${{ steps.set-release-facts.outputs.workflow_result_in_job }}
-        major_version: ${{ steps.set-release-facts.outputs.major_version }}
-        minor_version: ${{ steps.set-release-facts.outputs.minor_version }}
         commit: ${{ inputs.commit }}
         override_release_fact_workflow: ${{ inputs.override_release_fact_workflow || '' }}
 

--- a/.github/workflows/promote-stable.yml
+++ b/.github/workflows/promote-stable.yml
@@ -70,13 +70,13 @@ jobs:
       current_release_tag: ${{ steps.git-facts.outputs.current_release_tag }}
       current_release_tag_commit: ${{ steps.git-facts.outputs.current_release_tag_commit }}
       repo_short: ${{ steps.set-release-facts.outputs.repo_short }}
-      major_version: ${{ steps.set-release-facts.outputs.major_version }}
-      minor_version: ${{ steps.set-release-facts.outputs.minor_version }}
       release_tag_equals_latest_commit: ${{ steps.git-facts.outputs.release_tag_equals_latest_commit }}
       new_version_tag: ${{ steps.verify-release-candidate.outputs.new_version_tag }}
 
     name: Get Release Facts
     runs-on: ubuntu-latest
+    env:
+        GH_TOKEN: ${{ github.token }}
     steps:
     - uses: actions/checkout@v4
       with:
@@ -106,11 +106,15 @@ jobs:
             echo "current_release_tag=$current_release_tag"
             exit 1
         fi
-        new_version_tag="${{ steps.set-release-facts.outputs.major_version }}.${{ steps.set-release-facts.outputs.minor_version }}.0"
+
+        ./.github/scripts/get_version.sh "${{ steps.set-release-facts.outputs.version_repo_ref }}"
+        source .rendered_version
+        new_version_tag="${MAJOR}.${MINOR}.0"
 
         if [ "${{ inputs.draft }}" == "true" ]; then
             new_version_tag="draft.${{ steps.set-release-facts.outputs.repo_short }}.${new_version_tag}"
         fi
+
         echo "new_version_tag=$new_version_tag"
         echo "new_version_tag=$new_version_tag" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,19 +64,39 @@ permissions:
 
 jobs:
 
-  generate-seed:
+  generate-metadata:
     outputs:
       random-seed: ${{ steps.random.outputs.id }}
+      new_nightly_version_tag: ${{ steps.generate-nightly-version.outputs.new_nightly_version_tag }}
     runs-on: ubuntu-latest
+    env:
+        GH_TOKEN: ${{ github.token }}
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+    - name: Set Release Facts
+      id: set-release-facts
+      uses: ./.github/actions/set-release-facts
+      with:
+        repo: ${{ inputs.repo }}
+        release_type: ${{ inputs.release_type }}
+        draft: ${{ inputs.draft || false }}
     - name: Generate random seed
       uses: ./.github/actions/random
       id: random
+    - name: Generate Nightly Version
+      id: generate-nightly-version
+      if: ${{ inputs.release_type == 'nightly' }}
+      shell: bash
+      run: |
+        ./.github/scripts/get_version.sh "${{ steps.set-release-facts.outputs.version_repo_ref }}"
+        source .rendered_version
+        new_nightly_version_tag="${MAJOR}.${MINOR}.${PATCH}.dev$(date +"%Y%m%d")"
+        echo "new_nightly_version_tag=$new_nightly_version_tag"
+        echo "new_nightly_version_tag=$new_nightly_version_tag" >> $GITHUB_OUTPUT
 
   build-release:
-    needs: generate-seed
+    needs: generate-metadata
     name: "${{ inputs.draft && 'Draft' || '' }} Build Release ${{ inputs.repo_short }} ${{ inputs.release_type }} ${{ inputs.new_version_tag}} ${{ inputs.branch }}"
     outputs:
       release-artifacts-id: ${{ steps.build-release-wheel.outputs.release-artifacts-id }}
@@ -97,7 +117,7 @@ jobs:
         repo: ${{ inputs.repo }}
         release_type: ${{ inputs.release_type }}
         draft: ${{ inputs.draft }}
-        new_version_tag: ${{ inputs.new_version_tag }}
+        new_version_tag: ${{ inputs.new_version_tag || needs.generate-metadata.outputs.new_nightly_version_tag }}
         latest_branch_commit: ${{ inputs.latest_branch_commit }}
 
     - uses: mukunku/tag-exists-action@v1.6.0
@@ -118,7 +138,7 @@ jobs:
         latest_branch_commit: ${{ steps.set-release-facts.outputs.build_release_latest_branch_commit }}
         branch: ${{ inputs.branch || 'main' }}
         new_version_tag: ${{ steps.set-release-facts.outputs.build_release_tag }}
-        unique_artifact_suffix: ${{ needs.generate-seed.outputs.random-seed }}
+        unique_artifact_suffix: ${{ needs.generate-metadata.outputs.random-seed }}
         override_release_fact_workflow: ${{ inputs.override_release_fact_workflow }}
         workflow_allow_failed: ${{ inputs.workflow_allow_failed || steps.set-release-facts.outputs.workflow_allow_failed }}
 
@@ -143,7 +163,7 @@ jobs:
     if: ${{ inputs.draft || inputs.overwrite_releases || needs.build-release.outputs.check-tag == 'false'  }}
     needs:
       - build-release
-      - generate-seed
+      - generate-metadata
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -156,7 +176,7 @@ jobs:
           repo: ${{ inputs.repo }}
           release_type: ${{ inputs.release_type }}
           draft: ${{ inputs.draft }}
-          new_version_tag: ${{ inputs.new_version_tag }}
+          new_version_tag: ${{ inputs.new_version_tag || needs.generate-metadata.outputs.new_nightly_version_tag }}
 
       - name: Trigger Docker Basic test ${{ steps.set-release-facts.outputs.repo_short }}
         if: ${{  steps.set-release-facts.outputs.skip_docker_build == 'false' }}
@@ -165,11 +185,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         with:
-          workflow_name: "Basic tests"
-          parent_run_id: "basic-test-${{ steps.set-release-facts.outputs.repo_short }}-${{ steps.set-release-facts.outputs.gh_new_version_tag }}-${{ needs.generate-seed.outputs.random-seed }}"
+          workflow_name: "basic-tests.yml"
+          parent_run_id: "basic-test-${{ steps.set-release-facts.outputs.repo_short }}-${{ steps.set-release-facts.outputs.gh_new_version_tag }}-${{ needs.generate-metadata.outputs.random-seed }}"
           wait: false
           wait_for_run_url: true
-          json_params: '{"docker-image": "${{ needs.build-release.outputs.harbor_image_tag }}", "project-filter": "${{ steps.set-release-facts.outputs.repo_short }}" }'
+          json_params: '{"docker-image": "${{ needs.build-release.outputs.harbor_image_tag }}", "project-filter": "${{ steps.set-release-facts.outputs.test_basic_project_filter }}", "runner-filter": "${{ steps.set-release-facts.outputs.test_basic_runner_filter }}" }'
 
       - name: Trigger Docker Demo test ${{ steps.set-release-facts.outputs.repo_short }}
         if: ${{  steps.set-release-facts.outputs.skip_docker_build == 'false' }}
@@ -178,8 +198,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         with:
-          workflow_name: "Demo tests"
-          parent_run_id: "demo-test-${{ steps.set-release-facts.outputs.repo_short }}-${{ steps.set-release-facts.outputs.gh_new_version_tag }}-${{ needs.generate-seed.outputs.random-seed }}"
+          workflow_name: "demo-tests.yml"
+          parent_run_id: "demo-test-${{ steps.set-release-facts.outputs.repo_short }}-${{ steps.set-release-facts.outputs.gh_new_version_tag }}-${{ needs.generate-metadata.outputs.random-seed }}"
           wait: ${{ steps.set-release-facts.outputs.test_demo_wait }}
           wait_for_run_url: true
           json_params: '{"docker-image": "${{ needs.build-release.outputs.harbor_image_tag }}", "project-filter": "${{ steps.set-release-facts.outputs.repo_short }}", "test-filter": "${{ steps.set-release-facts.outputs.test_demo_filter }}" }'
@@ -198,7 +218,7 @@ jobs:
     needs:
       - build-release
       - test-release
-      - generate-seed
+      - generate-metadata
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -210,7 +230,7 @@ jobs:
           repo: ${{ inputs.repo }}
           release_type: ${{ inputs.release_type }}
           draft: ${{ inputs.draft }}
-          new_version_tag: ${{ inputs.new_version_tag }}
+          new_version_tag: ${{ inputs.new_version_tag || needs.generate-metadata.outputs.new_version_tag }}
 
       - name: Download Release Artifacts
         id: download-release-artifacts
@@ -286,5 +306,5 @@ jobs:
           repo_short: ${{ inputs.repo_short }}
           prerelease: ${{ inputs.prerelease || steps.set-release-facts.outputs.prerelease }}
           release-artifacts-id: ${{ needs.build-release.outputs.release-artifacts-id }}
-          unique_artifact_suffix: ${{ needs.generate-seed.outputs.random-seed }}
+          unique_artifact_suffix: ${{ needs.generate-metadata.outputs.random-seed }}
           make_latest: ${{ inputs.make_latest || steps.set-release-facts.outputs.make_latest }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ venv
 *.pyc
 __pycache__/**
 .vscode/**
+
+.rendered_version

--- a/.version
+++ b/.version
@@ -1,4 +1,2 @@
+# Only update the major when needed.
 MAJOR=0
-MINOR=3
-PATCH=0
-VERSION="$MAJOR.$MINOR.$PATCH"


### PR DESCRIPTION
WIP - DO NOT REVIEW

Changes:
   Auto bumps the version of a release based on the last created stable release. The major version will still need to be manually updated for releases that have nightly only; the ' version_repo_ref` can be used to point to a different repo's stable version.





Changed the workflow dispatch caller name to the yaml file version. The reason for this is that if an error occurs in the dev workflow, it will change the registered name.

<img width="637" height="164" alt="image" src="https://github.com/user-attachments/assets/2e5870bf-c4dc-4da5-9258-06050d925f4c" />

Using the {filename}.yaml fixes and avoids this issue

<img width="397" height="106" alt="image" src="https://github.com/user-attachments/assets/995fd932-ba46-4e8d-acc6-563bd75ec489" />

