### PR TITLE
Rename Forge slim docker build & test workflow

### DIFF
--- a/.github/workflows/mega-docker.yml
+++ b/.github/workflows/mega-docker.yml
@@ -1,4 +1,4 @@
-name: Build TT-Forge Docker Images
+name: Nightly Release & Tests
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
The Nightly release and testing workflows for Forge slim docker image has been renamed to better reflect what is actually happening in the workflow.

