### PR TITLE
bug: stash readme doc outside git path

### DIFF
--- a/.github/actions/docs-generator/action.yml
+++ b/.github/actions/docs-generator/action.yml
@@ -214,7 +214,7 @@ runs:
     - name: output readme
       shell: bash
       run: |
-        readme_path="${{ github.workspace }}/release/docs"
+        readme_path="/tmp/release/docs"
         mkdir -p $readme_path
 
         new_version_tag="${{ inputs.new_version_tag }}"

--- a/.github/actions/publish-github-release/action.yml
+++ b/.github/actions/publish-github-release/action.yml
@@ -64,7 +64,7 @@ runs:
     - name: Publish GitHub Release
       uses: softprops/action-gh-release@v2
       with:
-        body_path: "${{ github.workspace }}/release/docs/readme"
+        body_path: "/tmp/release/docs/readme"
         token: ${{ inputs.release_token }}
         name: ${{ steps.set-name.outputs.name }}
         tag_name: ${{ inputs.new_version_tag }}


### PR DESCRIPTION
The bug is caused by the git tag annotated checkout, which wipes the git path clean and removes the generated release doc. This issue did not surface in workflow draft testing because we do not check out other repos during that test. The fix is to store the doc in the temp path of the runner

```bash
⚠️ Unexpected error fetching GitHub release for tag refs/heads/main: Error: ENOENT: no such file or directory, open '/home/runner/work/tt-forge/tt-forge/release/docs/readme'
Error: ENOENT: no such file or directory, open '/home/runner/work/tt-forge/tt-forge/release/docs/readme'
```
https://github.com/tenstorrent/tt-forge/actions/runs/16929016574/job/47971430850#step:9:117

We can't change the Git path checkout due to the issues documented in the `For the git checkout issue` section.
https://github.com/tenstorrent/tt-forge/issues/192

