### PR TITLE
Change shared runner labels to new label

### DIFF
--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           json_matrix="[]"
           frontends="tt-forge-fe tt-torch tt-xla"
-          runs_on="tt-beta-ubuntu-2204-n150-large-stable tt-beta-ubuntu-2204-p150b-large-stable"
+          runs_on="tt-ubuntu-2204-n150-stable tt-ubuntu-2204-p150b-stable"
 
           if [ -n "${{ inputs.project-filter }}" ]; then
             frontends="${{ inputs.project-filter }}"

--- a/.github/workflows/demo-tests.yml
+++ b/.github/workflows/demo-tests.yml
@@ -97,7 +97,7 @@ jobs:
       matrix:
         include: ${{ fromJson(needs.set-matrix.outputs.matrix) }}
 
-    runs-on: ${{ matrix.runs-on && format('tt-beta-ubuntu-2204-{0}-large-stable', matrix.runs-on) }}
+    runs-on: ${{ matrix.runs-on && format('tt-ubuntu-2204-{0}-stable', matrix.runs-on) }}
     container:
       image: ${{ inputs.docker-image }}
       options: --device /dev/tenstorrent

--- a/.github/workflows/mega-docker.yml
+++ b/.github/workflows/mega-docker.yml
@@ -20,8 +20,6 @@ jobs:
 
   build-tt-forge-slim:
     name: Build tt-forge-slim Docker Image
-    # runs-on: tt-beta-ubuntu-2204-large
-    # TODO We cant use tt-beta-ubuntu-2204-large until we whitelist pypi.eng.aws.tenstorrent.com on proxy
     runs-on: ubuntu-latest
     outputs:
       docker-image: ${{ steps.build.outputs.docker-image }}

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -136,7 +136,7 @@ jobs:
       matrix:
         build: ${{ fromJson(needs.filter-tests.outputs.benchmark-matrix) }}
 
-    runs-on: ${{ inputs.sh-runner && format('tt-beta-ubuntu-2204-{0}-large-stable', matrix.build.runs-on) || fromJson(format('["{0}-perf", "in-service"]', matrix.build.runs-on)) }}
+    runs-on: ${{ inputs.sh-runner && format('tt-ubuntu-2204-{0}-stable', matrix.build.runs-on) || fromJson(format('["{0}-perf", "in-service"]', matrix.build.runs-on)) }}
 
     env:
       # TODO: Revisit the addition of these env vars https://github.com/tenstorrent/tt-metal/issues/20161


### PR DESCRIPTION
We need to migrate to the new labels set by CIv2 team