### PR TITLE
Fix: Trigger collect data for the renamed nightly release workflow

### DIFF
--- a/.github/workflows/produce_data.yml
+++ b/.github/workflows/produce_data.yml
@@ -5,7 +5,7 @@ on:
   workflow_run:
     workflows: # List workflow that we want to collect data for
       - "Performance benchmark"
-      - "Build TT-Forge Docker Images"
+      - "Nightly Release & Tests"
       - "Demo tests"
       - "Performance Benchmark External Trigger"
     types:


### PR DESCRIPTION
The performance test data from the `Nightly Release & Tests` workflow wasn't collected.

`[internal] Collect workflow data` requires the exact name of the workflows it should trigger after, when `Nightly Release & Tests` name changed that broke.

`Nightly Release & Tests`  has been added as a trigger for the data collecting workflow.