### PR TITLE
bug: fix repo arg in annotated tag 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,7 +267,7 @@ jobs:
       - uses: ./.github/actions/push-annotated-git-tag
         if: ${{ !(inputs.release_type == 'nightly' && inputs.draft == true) }}
         with:
-          repo: ${{ inputs.repo }}
+          repo: ${{ steps.set-release-facts.outputs.repo_full }}
           draft: ${{ inputs.draft }}
           GH_TOKEN: ${{ secrets.TT_FORGE_RELEASER }}
           new_version_tag: ${{ steps.set-release-facts.outputs.gh_new_version_tag }}


### PR DESCRIPTION
This bug is caused by not supplying the full repo name for the annotated tag action, which only affects user-triggered workflow dispatches, e.g., ([Create Version Branches](https://github.com/tenstorrent/tt-forge/actions/workflows/create-version-branches.yml) ). Automated releases, such as Nightly releases, are not affected.

```bash
Error: Invalid repository 'tt-torch'. Expected format {owner}/{repo}.
```
https://github.com/tenstorrent/tt-forge/actions/runs/17000074653/job/48202880263#step:8:54

The fix is to use the [repo_full](https://github.com/tenstorrent/tt-forge/blob/main/.github/actions/set-release-facts/action.yaml#L135) in set release facts, which is always returns with the full repo name.