### PR TITLE
Add multi-variant, multi-source & multi-task support for tt-forge model demos - set1

### DIFF
--- a/demos/tt-forge-fe/cnn/dla_demo.py
+++ b/demos/tt-forge-fe/cnn/dla_demo.py
@@ -4,18 +4,46 @@
 # Dla Demo Script
 
 import forge
-from third_party.tt_forge_models.dla.pytorch import ModelLoader
+from third_party.tt_forge_models.dla.pytorch import ModelLoader, ModelVariant
 
-# Load model and input
-loader = ModelLoader()
-model = loader.load_model()
-inputs = loader.load_inputs()
 
-# Compile the model using Forge
-compiled_model = forge.compile(model, sample_inputs=[inputs])
+def run_dla_demo_case(variant):
 
-# Run inference on Tenstorrent device
-output = compiled_model(inputs)
+    # Load Model and inputs
+    loader = ModelLoader(variant=variant)
+    model = loader.load_model()
+    inputs = loader.load_inputs()
 
-# Post-process the output
-loader.print_cls_results(output)
+    # Compile the model using Forge
+    compiled_model = forge.compile(model, sample_inputs=[inputs])
+
+    # Run inference on Tenstorrent device
+    output = compiled_model(inputs)
+
+    # Post-process and display results
+    loader.print_cls_results(output)
+
+    print("=" * 60, flush=True)
+
+
+if __name__ == "__main__":
+
+    demo_cases = [
+        # TORCH_HUB variants
+        ModelVariant.DLA34,
+        ModelVariant.DLA46_C,
+        ModelVariant.DLA46X_C,
+        ModelVariant.DLA60,
+        ModelVariant.DLA60X,
+        ModelVariant.DLA60X_C,
+        ModelVariant.DLA102,
+        ModelVariant.DLA102X,
+        ModelVariant.DLA102X2,
+        ModelVariant.DLA169,
+        # TIMM variants
+        ModelVariant.DLA34_IN1K,
+    ]
+
+    # Run each demo case
+    for variant in demo_cases:
+        run_dla_demo_case(variant)

--- a/demos/tt-forge-fe/cnn/ghostnet_demo.py
+++ b/demos/tt-forge-fe/cnn/ghostnet_demo.py
@@ -3,19 +3,39 @@
 
 # Ghostnet Demo Script
 
+import sys
 import forge
-from third_party.tt_forge_models.ghostnet.pytorch import ModelLoader
+from third_party.tt_forge_models.ghostnet.pytorch import ModelLoader, ModelVariant
 
-# Load model and input
-loader = ModelLoader()
-model = loader.load_model()
-inputs = loader.load_inputs()
 
-# Compile the model using Forge
-compiled_model = forge.compile(model, sample_inputs=[inputs])
+def run_ghostnet_demo_case(variant):
 
-# Run inference on Tenstorrent device
-output = compiled_model(inputs)
+    # Load Model and inputs
+    loader = ModelLoader(variant=variant)
+    model = loader.load_model()
+    inputs = loader.load_inputs()
 
-# Post-process the output
-loader.post_processing(output)
+    # Compile the model using Forge
+    compiled_model = forge.compile(model, sample_inputs=[inputs])
+
+    # Run inference on Tenstorrent device
+    output = compiled_model(inputs)
+
+    # Post-process and display results
+    loader.post_processing(output)
+
+    print("=" * 60, flush=True)
+
+
+if __name__ == "__main__":
+
+    demo_cases = [
+        # TIMM variants
+        ModelVariant.GHOSTNET_100,
+        ModelVariant.GHOSTNET_100_IN1K,
+        ModelVariant.GHOSTNETV2_100_IN1K,
+    ]
+
+    # Run each demo case
+    for variant in demo_cases:
+        run_ghostnet_demo_case(variant)

--- a/demos/tt-forge-fe/cnn/inception_demo.py
+++ b/demos/tt-forge-fe/cnn/inception_demo.py
@@ -1,14 +1,14 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
-# Segformer Demo Script
+# Inception Demo Script
 
 import sys
 import forge
-from third_party.tt_forge_models.segformer.pytorch import ModelLoader, ModelVariant
+from third_party.tt_forge_models.inception.pytorch import ModelLoader, ModelVariant
 
 
-def run_segformer_demo_case(variant):
+def run_inception_demo_case(variant):
 
     # Load Model and inputs
     loader = ModelLoader(variant=variant)
@@ -22,7 +22,7 @@ def run_segformer_demo_case(variant):
     output = compiled_model(inputs)
 
     # Post-process and display results
-    loader.post_processing(output)
+    loader.print_cls_results(output)
 
     print("=" * 60, flush=True)
 
@@ -30,15 +30,11 @@ def run_segformer_demo_case(variant):
 if __name__ == "__main__":
 
     demo_cases = [
-        # SegFormer variants
-        ModelVariant.MIT_B0,
-        ModelVariant.MIT_B1,
-        ModelVariant.MIT_B2,
-        ModelVariant.MIT_B3,
-        ModelVariant.MIT_B4,
-        ModelVariant.MIT_B5,
+        # TIMM variants
+        ModelVariant.INCEPTION_V4,
+        ModelVariant.INCEPTION_V4_TF_IN1K,
     ]
 
     # Run each demo case
     for variant in demo_cases:
-        run_segformer_demo_case(variant)
+        run_inception_demo_case(variant)

--- a/demos/tt-forge-fe/cnn/mobile_netv1_demo.py
+++ b/demos/tt-forge-fe/cnn/mobile_netv1_demo.py
@@ -3,19 +3,42 @@
 
 # MobileNetV1 Demo Script
 
+import sys
 import forge
-from third_party.tt_forge_models.mobilenetv1.pytorch import ModelLoader
+from third_party.tt_forge_models.mobilenetv1.pytorch import ModelLoader, ModelVariant
 
-# Load model and input
-loader = ModelLoader()
-model = loader.load_model()
-inputs = loader.load_inputs()
 
-# Compile the model using Forge
-compiled_model = forge.compile(model, sample_inputs=[inputs])
+def run_mobilenetv1_demo_case(variant):
 
-# Run inference on Tenstorrent device
-output = compiled_model(inputs)
+    # Load Model and inputs
+    loader = ModelLoader(variant=variant)
+    model = loader.load_model()
+    inputs = loader.load_inputs()
 
-# Post-process the output
-loader.print_cls_results(output)
+    # Compile the model using Forge
+    compiled_model = forge.compile(model, sample_inputs=[inputs])
+
+    # Run inference on Tenstorrent device
+    output = compiled_model(inputs)
+
+    # Post-process and display results
+    loader.print_cls_results(output)
+
+    print("=" * 60, flush=True)
+
+
+if __name__ == "__main__":
+
+    demo_cases = [
+        # GitHub variants
+        ModelVariant.MOBILENET_V1_GITHUB,
+        # HuggingFace variants
+        ModelVariant.MOBILENET_V1_075_192_HF,
+        ModelVariant.MOBILENET_V1_100_224_HF,
+        # TIMM variants
+        ModelVariant.MOBILENET_V1_100_TIMM,
+    ]
+
+    # Run each demo case
+    for variant in demo_cases:
+        run_mobilenetv1_demo_case(variant)

--- a/demos/tt-forge-fe/cnn/mobile_netv2_demo.py
+++ b/demos/tt-forge-fe/cnn/mobile_netv2_demo.py
@@ -3,19 +3,40 @@
 
 # MobileNetV2 Demo Script
 
+import sys
 import forge
-from third_party.tt_forge_models.mobilenetv2.pytorch import ModelLoader
+from third_party.tt_forge_models.mobilenetv2.pytorch import ModelLoader, ModelVariant
 
-# Load model and input
-loader = ModelLoader()
-model = loader.load_model()
-inputs = loader.load_inputs()
 
-# Compile the model using Forge
-compiled_model = forge.compile(model, sample_inputs=[inputs])
+def run_mobilenetv2_demo_case(variant):
 
-# Run inference on Tenstorrent device
-output = compiled_model(inputs)
+    # Load Model and inputs
+    loader = ModelLoader(variant=variant)
+    model = loader.load_model()
+    inputs = loader.load_inputs()
 
-# Post-process the output
-loader.print_cls_results(output)
+    # Compile the model using Forge
+    compiled_model = forge.compile(model, sample_inputs=[inputs])
+
+    # Run inference on Tenstorrent device
+    output = compiled_model(inputs)
+
+    # Post-process and display results
+    loader.print_cls_results(output)
+
+    print("=" * 60, flush=True)
+
+
+if __name__ == "__main__":
+
+    demo_cases = [
+        # HuggingFace variants
+        ModelVariant.MOBILENET_V2_075_160_HF,
+        ModelVariant.MOBILENET_V2_100_224_HF,
+        # TIMM variants
+        ModelVariant.MOBILENET_V2_100_TIMM,
+    ]
+
+    # Run each demo case
+    for variant in demo_cases:
+        run_mobilenetv2_demo_case(variant)

--- a/demos/tt-forge-fe/cnn/mobile_netv3_demo.py
+++ b/demos/tt-forge-fe/cnn/mobile_netv3_demo.py
@@ -1,14 +1,14 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
-# Segformer Demo Script
+# MobileNetV3 Demo Script
 
 import sys
 import forge
-from third_party.tt_forge_models.segformer.pytorch import ModelLoader, ModelVariant
+from third_party.tt_forge_models.mobilenetv3.pytorch import ModelLoader, ModelVariant
 
 
-def run_segformer_demo_case(variant):
+def run_mobilenetv3_demo_case(variant):
 
     # Load Model and inputs
     loader = ModelLoader(variant=variant)
@@ -22,7 +22,7 @@ def run_segformer_demo_case(variant):
     output = compiled_model(inputs)
 
     # Post-process and display results
-    loader.post_processing(output)
+    loader.print_cls_results(output)
 
     print("=" * 60, flush=True)
 
@@ -30,15 +30,14 @@ def run_segformer_demo_case(variant):
 if __name__ == "__main__":
 
     demo_cases = [
-        # SegFormer variants
-        ModelVariant.MIT_B0,
-        ModelVariant.MIT_B1,
-        ModelVariant.MIT_B2,
-        ModelVariant.MIT_B3,
-        ModelVariant.MIT_B4,
-        ModelVariant.MIT_B5,
+        # TORCH_HUB variants
+        # ModelVariant.MOBILENET_V3_LARGE,
+        ModelVariant.MOBILENET_V3_SMALL,
+        # TIMM variants
+        # ModelVariant.MOBILENET_V3_LARGE_100_TIMM,
+        ModelVariant.MOBILENET_V3_SMALL_100_TIMM,
     ]
 
     # Run each demo case
     for variant in demo_cases:
-        run_segformer_demo_case(variant)
+        run_mobilenetv3_demo_case(variant)

--- a/demos/tt-forge-fe/cnn/resnext_demo.py
+++ b/demos/tt-forge-fe/cnn/resnext_demo.py
@@ -3,19 +3,44 @@
 
 # ResNext Demo Script
 
+import sys
 import forge
-from third_party.tt_forge_models.resnext.pytorch import ModelLoader
+from third_party.tt_forge_models.resnext.pytorch import ModelLoader, ModelVariant
 
-# Load model and input
-loader = ModelLoader()
-model = loader.load_model()
-inputs = loader.load_inputs()
 
-# Compile the model using Forge
-compiled_model = forge.compile(model, sample_inputs=[inputs])
+def run_resnext_demo_case(variant):
 
-# Run inference on Tenstorrent device
-output = compiled_model(inputs)
+    # Load Model and inputs
+    loader = ModelLoader(variant=variant)
+    model = loader.load_model()
+    inputs = loader.load_inputs()
 
-# Post-process the output
-loader.print_cls_results(output)
+    # Compile the model using Forge
+    compiled_model = forge.compile(model, sample_inputs=[inputs])
+
+    # Run inference on Tenstorrent device
+    output = compiled_model(inputs)
+
+    # Post-process and display results
+    loader.print_cls_results(output)
+
+    print("=" * 60, flush=True)
+
+
+if __name__ == "__main__":
+
+    demo_cases = [
+        # TORCH_HUB variants
+        ModelVariant.RESNEXT50_32X4D,
+        ModelVariant.RESNEXT101_32X8D,
+        ModelVariant.RESNEXT101_32X8D_WSL,
+        # OSMR variants
+        ModelVariant.RESNEXT14_32X4D_OSMR,
+        ModelVariant.RESNEXT26_32X4D_OSMR,
+        ModelVariant.RESNEXT50_32X4D_OSMR,
+        ModelVariant.RESNEXT101_64X4D_OSMR,
+    ]
+
+    # Run each demo case
+    for variant in demo_cases:
+        run_resnext_demo_case(variant)

--- a/demos/tt-forge-fe/cnn/swin_demo.py
+++ b/demos/tt-forge-fe/cnn/swin_demo.py
@@ -3,19 +3,45 @@
 
 # Swin Demo Script
 
+import sys
 import forge
-from third_party.tt_forge_models.swin.pytorch import ModelLoader
+from third_party.tt_forge_models.swin.image_classification.pytorch import ModelLoader, ModelVariant
 
-# Load model and input
-loader = ModelLoader()
-model = loader.load_model()
-inputs = loader.load_inputs()
 
-# Compile the model using Forge
-compiled_model = forge.compile(model, sample_inputs=[inputs])
+def run_swin_demo_case(variant):
 
-# Run inference on Tenstorrent device
-output = compiled_model(inputs)
+    # Load Model and inputs
+    loader = ModelLoader(variant=variant)
+    model = loader.load_model()
+    inputs = loader.load_inputs()
 
-# Post-process the output
-loader.print_cls_results(output)
+    # Compile the model using Forge
+    compiled_model = forge.compile(model, sample_inputs=[inputs])
+
+    # Run inference on Tenstorrent device
+    output = compiled_model(inputs)
+
+    # Post-process and display results
+    loader.print_cls_results(output)
+
+    print("=" * 60, flush=True)
+
+
+if __name__ == "__main__":
+
+    demo_cases = [
+        # HuggingFace variants
+        ModelVariant.SWIN_TINY_HF,
+        # Torchvision variants - Swin V1
+        ModelVariant.SWIN_T,
+        ModelVariant.SWIN_S,
+        ModelVariant.SWIN_B,
+        # Torchvision variants - Swin V2
+        ModelVariant.SWIN_V2_T,
+        ModelVariant.SWIN_V2_S,
+        ModelVariant.SWIN_V2_B,
+    ]
+
+    # Run each demo case
+    for variant in demo_cases:
+        run_swin_demo_case(variant)

--- a/demos/tt-forge-fe/cnn/vit_demo.py
+++ b/demos/tt-forge-fe/cnn/vit_demo.py
@@ -3,19 +3,44 @@
 
 # VIT Demo Script
 
+import sys
 import forge
-from third_party.tt_forge_models.vit.pytorch import ModelLoader
+from third_party.tt_forge_models.vit.pytorch import ModelLoader, ModelVariant
 
-# Load model and input
-loader = ModelLoader()
-model = loader.load_model()
-inputs = loader.load_inputs()
 
-# Compile the model using Forge
-compiled_model = forge.compile(model, sample_inputs=[inputs])
+def run_vit_demo_case(variant):
 
-# Run inference on Tenstorrent device
-output = compiled_model(inputs)
+    # Load Model and inputs
+    loader = ModelLoader(variant=variant)
+    model = loader.load_model()
+    inputs = loader.load_inputs()
 
-# Post-process the output
-loader.post_processing(output)
+    # Compile the model using Forge
+    compiled_model = forge.compile(model, sample_inputs=[inputs])
+
+    # Run inference on Tenstorrent device
+    output = compiled_model(inputs)
+
+    # Post-process and display results
+    loader.post_processing(output)
+
+    print("=" * 60, flush=True)
+
+
+if __name__ == "__main__":
+
+    demo_cases = [
+        # HuggingFace variants
+        ModelVariant.BASE,
+        ModelVariant.LARGE,
+        # Torchvision variants
+        ModelVariant.VIT_B_16,
+        ModelVariant.VIT_B_32,
+        ModelVariant.VIT_L_16,
+        ModelVariant.VIT_L_32,
+        ModelVariant.VIT_H_14,
+    ]
+
+    # Run each demo case
+    for variant in demo_cases:
+        run_vit_demo_case(variant)


### PR DESCRIPTION
### Ticket
Fixes https://github.com/tenstorrent/tt-forge/issues/365

### Problem description
Add multi-variant, multi-source, and multi-task support for model demos in tt-forge 

### What's changed
This PR introduces multi-variant and multi-source support for the following models:
  - DLA
  - GhostNet
  - Inception
  - MobileNetV1
  - MobileNetV2
  - MobileNetV3
  - ResNeXt
  - SegFormer
  - Swin
  - ViT 

### Checklist

- [x] Verified the changes with local testing

### Logs

[set1_demos.zip](https://github.com/user-attachments/files/21837400/set1_demos.zip)

