### PR TITLE
Performance tests custom ttrt wheel download

### DIFF
--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -200,14 +200,16 @@ jobs:
       shell: bash
       run: |
         source /home/forge/venv-${{ matrix.build.project }}/bin/activate
+
         project_name=$(echo "${{ matrix.build.project }}" | tr "-" "_")
         if [[ "${{ matrix.build.project }}" == "tt-xla" ]]; then
           project_name="pjrt_plugin_tt"
         fi
+
         version=$(pip freeze | grep -oP "(?<=$project_name-)[^-]+")
         echo "Wheel version: $version"
-        mlir_sha=""
 
+        mlir_sha=""
         if [[ "${{ matrix.build.project }}" == "tt-torch" || "${{ matrix.build.project }}" == "tt-xla" ]]; then
           wget "https://raw.githubusercontent.com/tenstorrent/${{ matrix.build.project }}/${version}/third_party/CMakeLists.txt"
           mlir_sha=$(grep -E "set\(TT_MLIR_VERSION" CMakeLists.txt | grep -oP '"\K[^"]+' | head -n 1)
@@ -215,7 +217,6 @@ jobs:
           mlir_sha=$(curl -s "https://api.github.com/repos/tenstorrent/tt-forge-fe/contents/third_party/tt-mlir?ref=${version}" | \
             grep '"sha"' | head -1 | cut -d'"' -f4)
         fi
-
         echo "Mlir commit sha: $mlir_sha"
 
         RUN_ID=$(curl -s \


### PR DESCRIPTION
#### Issue
In the performance tests we were always downloading the ttrt wheel from the HEAD of the main branch.
That caused issues because the frontend wheel could be from a different commit and then compatibility is problematic.

#### Solution
With the new approach, we always download the ttrt wheel from the same commit as the mlir version used by the frontend wheel.