### PR TITLE
bug: fix tt-forge-slim demo test

### DIFF
--- a/.github/workflows/demo-tests.yml
+++ b/.github/workflows/demo-tests.yml
@@ -163,8 +163,8 @@ jobs:
         run: |
           if [ -f /home/forge/venv-${{ matrix.frontend }}/bin/activate ]; then
             echo "Using /home/forge/venv-${{ matrix.frontend }}"
-            pip list | grep -E 'tt_|tt-|pjrt-' # Print installed version
             source /home/forge/venv-${{ matrix.frontend }}/bin/activate
+            pip list | grep -E 'tt_|tt-|pjrt-' # Print installed version
           fi
 
           third_party_models="$(realpath third_party)"


### PR DESCRIPTION
Fixes an issue where the Python frontend version was checked before accessing the venv.
https://github.com/tenstorrent/tt-forge/actions/runs/17080975708

This change mirrors what is working in [basic test](https://github.com/tenstorrent/tt-forge/blob/main/.github/workflows/basic-tests.yml#L114-L116)


Tested by triggering the workflow dispatch.
https://github.com/tenstorrent/tt-forge/actions/runs/17080975708/job/48437058005#step:6:23