### PR TITLE
Use CIv2 CPU runners for building the mega docker image & minor fixes

### DIFF
--- a/.github/workflows/mega-docker.yml
+++ b/.github/workflows/mega-docker.yml
@@ -20,7 +20,7 @@ jobs:
 
   build-tt-forge-slim:
     name: Build tt-forge-slim Docker Image
-    runs-on: ubuntu-latest
+    runs-on: tt-ubuntu-2204-large-stable
     outputs:
       docker-image: ${{ steps.build.outputs.docker-image }}
       docker-image-harbor: ${{ steps.build.outputs.docker-image-harbor }}

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -208,7 +208,7 @@ jobs:
 
         version=""
         echo "Set version to commit sha if called from other repo"
-        if [[ "${{ inputs.run_id }}" ]]; then
+        if [[ -n "${{ inputs.run_id }}" ]]; then
           version=$(curl -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             "https://api.github.com/repos/tenstorrent/${{ matrix.build.project }}/actions/runs/${{ inputs.run_id }}" | jq -r '.head_sha')
         else

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -229,7 +229,7 @@ jobs:
 
         RUN_ID=$(curl -s \
           -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-          "https://api.github.com/repos/tenstorrent/tt-mlir/actions/workflows/on-push.yml/runs?status=success&head_sha=${mlir_sha}&per_page=1" \
+          "https://api.github.com/repos/tenstorrent/tt-mlir/actions/workflows/on-push.yml/runs?head_sha=${mlir_sha}&per_page=1" \
           | jq -r '.workflow_runs[0].id')
         echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
         echo "Workflow URL: https://github.com/tenstorrent/tt-mlir/actions/runs/$RUN_ID"

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -253,6 +253,7 @@ jobs:
         echo "Install ttrt"
         python -m venv ttrt-venv
         source ttrt-venv/bin/activate
+        apt-get update -y -qq
         apt-get install -y -qq --no-install-recommends libtbb12 libcapstone4
         pip install ttrt-whl-tracy/ttrt*.whl --upgrade
         pip install torch==2.3.0 --index-url https://download.pytorch.org/whl/cpu

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -212,7 +212,7 @@ jobs:
           version=$(curl -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             "https://api.github.com/repos/tenstorrent/${{ matrix.build.project }}/actions/runs/${{ inputs.run_id }}" | jq -r '.head_sha')
         else
-          version=$(pip freeze | grep -oP "(?<=$(echo $project_name)-)[^-]+")
+          version=$(pip freeze | grep -oP "(?<=$project_name-)[^-]+")
         fi
 
         echo "Wheel version: $version"


### PR DESCRIPTION
#### Issue 1
The mega docker image build step has started throwing an out of disk space error (i.e. `ERROR: Could not install packages due to an OSError: [Errno 28] No space left on device`)

The job has been changed to use the CIv2 CPU runners because of more disk space in total.

#### Issue 2
When frontends use tt-mlir version with failed on-push workflow the ttrt won't be downloaded.

This PR changes this and allows the ttrt wheel to be downloaded from the on-push workflow, irrespective of the workflow's status.

#### Issue 3
In the `Install ttrt` step the `apt-get install` fails with `Unable to fetch some archives`

Do a `apt-get update` before `apt-get install` to resolve the missing archives fetch fail.

#### Improvement
Make the behaviour more clear in the syntax (if syntax and regex syntax).

### Tests
The nightly release and tests workflow triggered on this PR: [workflow](https://github.com/tenstorrent/tt-forge/actions/runs/17202995236).