### PR TITLE
Reschedule the nigthly releases for 2 hours earlier

### DIFF
--- a/.github/workflows/daily-releaser.yml
+++ b/.github/workflows/daily-releaser.yml
@@ -2,7 +2,7 @@ name: Daily Releaser
 
 on:
   schedule:
-  - cron: '0 3 * * *'
+  - cron: '0 4 * * *'
   workflow_dispatch:
     inputs:
       draft:

--- a/.github/workflows/mega-docker.yml
+++ b/.github/workflows/mega-docker.yml
@@ -8,7 +8,7 @@ on:
         type: boolean
         default: false
   schedule:
-    - cron: '0 4 * * *'
+    - cron: '0 5 * * *'
 
 
 permissions:


### PR DESCRIPTION
[Issue](https://github.com/tenstorrent/tt-forge/issues/371)

TT-Forge nightly performance benchmark results need to be available earlier, so nightly frontend releases and nightly mega docker release & tests need to be rescheduled for 2 hours earlier.

### What's changed
Frontend releases are now scheduled for 2 hours earlier.
Mega docker build and testing is now scheduled for 2 hours earlier.

As the result of this PR the Performance Benchmark results should be available every day at 09:00 (CET) at the latest.