### PR TITLE
Python wheel artifact regex name support

### DIFF
--- a/.github/actions/install-wheel/action.yml
+++ b/.github/actions/install-wheel/action.yml
@@ -84,7 +84,6 @@ runs:
     - name: Install wheel
       shell: bash
       run: |
-        ls -lah
         if [ -n "${{ inputs.venv_bin_path }}" ]; then
           source ${{ inputs.venv_bin_path }}
         fi

--- a/.github/actions/install-wheel/action.yml
+++ b/.github/actions/install-wheel/action.yml
@@ -84,6 +84,7 @@ runs:
     - name: Install wheel
       shell: bash
       run: |
+        ls -lah
         if [ -n "${{ inputs.venv_bin_path }}" ]; then
           source ${{ inputs.venv_bin_path }}
         fi

--- a/.github/actions/install-wheel/action.yml
+++ b/.github/actions/install-wheel/action.yml
@@ -30,13 +30,16 @@ runs:
         if [ "${{ inputs.project }}" = "tt-forge-fe" ]; then
           echo "artifact=forge-wheel" >> $GITHUB_OUTPUT
           echo "wheel_name=tt_*" >> $GITHUB_OUTPUT
+          echo "artifact_is_regex='false'" >> $GITHUB_OUTPUT
         elif [ "${{ inputs.project }}" = "tt-torch" ]; then
           echo "artifact=install-artifacts-release" >> $GITHUB_OUTPUT
           echo "wheel_name=wheels/tt_*" >> $GITHUB_OUTPUT
           echo "untar='true'" >> $GITHUB_OUTPUT
+          echo "artifact_is_regex='false'" >> $GITHUB_OUTPUT
         elif [ "${{ inputs.project }}" = "tt-xla" ]; then
-          echo "artifact=xla-whl-release" >> $GITHUB_OUTPUT
+          echo "artifact=^xla-whl-release.*" >> $GITHUB_OUTPUT
           echo "wheel_name=pjrt_*" >> $GITHUB_OUTPUT
+          echo "artifact_is_regex='true'" >> $GITHUB_OUTPUT
         else
           echo "Unknown project: ${{ inputs.project }}"
           exit 1
@@ -57,7 +60,7 @@ runs:
       with:
         run_id: ${{ inputs.run_id }}
         name: "${{ steps.set-wheel-name.outputs.artifact }}"
-        name_is_regexp: false
+        name_is_regexp: "${{ steps.set-wheel-name.outputs.artifact_is_regex}}"
         repo: "tenstorrent/${{ steps.set-wheel-name.outputs.run_id_source }}"
         check_artifacts: true
 
@@ -69,7 +72,7 @@ runs:
         workflow: on-push.yml
         branch: main
         name: "${{ steps.set-wheel-name.outputs.artifact }}"
-        name_is_regexp: false
+        name_is_regexp: "${{ steps.set-wheel-name.outputs.artifact_is_regex}}"
         repo: "tenstorrent/${{ inputs.project }}"
         check_artifacts: true
 

--- a/.github/actions/install-wheel/action.yml
+++ b/.github/actions/install-wheel/action.yml
@@ -30,16 +30,16 @@ runs:
         if [ "${{ inputs.project }}" = "tt-forge-fe" ]; then
           echo "artifact=forge-wheel" >> $GITHUB_OUTPUT
           echo "wheel_name=tt_*" >> $GITHUB_OUTPUT
-          echo "artifact_is_regex='false'" >> $GITHUB_OUTPUT
+          echo "artifact_is_regex=false" >> $GITHUB_OUTPUT
         elif [ "${{ inputs.project }}" = "tt-torch" ]; then
           echo "artifact=install-artifacts-release" >> $GITHUB_OUTPUT
           echo "wheel_name=wheels/tt_*" >> $GITHUB_OUTPUT
           echo "untar='true'" >> $GITHUB_OUTPUT
-          echo "artifact_is_regex='false'" >> $GITHUB_OUTPUT
+          echo "artifact_is_regex=false" >> $GITHUB_OUTPUT
         elif [ "${{ inputs.project }}" = "tt-xla" ]; then
           echo "artifact=^xla-whl-release.*" >> $GITHUB_OUTPUT
           echo "wheel_name=pjrt_*" >> $GITHUB_OUTPUT
-          echo "artifact_is_regex='true'" >> $GITHUB_OUTPUT
+          echo "artifact_is_regex=true" >> $GITHUB_OUTPUT
         else
           echo "Unknown project: ${{ inputs.project }}"
           exit 1

--- a/.github/actions/install-wheel/action.yml
+++ b/.github/actions/install-wheel/action.yml
@@ -88,4 +88,7 @@ runs:
         if [ -n "${{ inputs.venv_bin_path }}" ]; then
           source ${{ inputs.venv_bin_path }}
         fi
+        if [ "${{ steps.set-wheel-name.outputs.artifact_is_regex }}" == "true" ]; then
+          cd $(ls | grep -E "${{ steps.set-wheel-name.outputs.artifact }}")
+        fi
         pip install ${{ steps.set-wheel-name.outputs.wheel_name }} --upgrade


### PR DESCRIPTION
Tt-xla is now producing wheel artifacts with a commit hash suffix (e.g. xla-whl-release-ae32o52).

That will break the exact name matching we have in the install-wheel action in tt-forge so we need to allow for any suffix in the name to be matched.