### PR TITLE
Refactor torch-xla perf benchmark utilities

### DIFF
--- a/benchmark/tt-xla/efficientnet.py
+++ b/benchmark/tt-xla/efficientnet.py
@@ -5,9 +5,7 @@
 # Built-in modules
 import os
 import time
-import socket
 import pytest
-from datetime import datetime
 
 # Third-party modules
 import torch
@@ -19,6 +17,13 @@ from benchmark.utils import load_benchmark_dataset, evaluate_classification, mea
 from third_party.tt_forge_models.efficientnet.pytorch.loader import (
     ModelLoader as EfficientNetLoader,
     ModelVariant as EfficientNetVariant,
+)
+from .utils import (
+    calculate_performance_metrics,
+    get_benchmark_metadata,
+    determine_model_type_and_dataset,
+    print_benchmark_results,
+    create_benchmark_result,
 )
 
 os.environ["PJRT_DEVICE"] = "TT"
@@ -76,8 +81,6 @@ def test_efficientnet_torch_xla(
     PROGRAM_CACHE_ENABLED = False
     MEMORY_LAYOUT_ANALYSIS_ENABLED = False
     TRACE_ENABLED = False
-
-    module_name = "EfficientNetTorchXLA"
 
     if task == "classification":
         inputs, labels = load_benchmark_dataset(
@@ -159,116 +162,64 @@ def test_efficientnet_torch_xla(
     else:
         raise ValueError(f"Unsupported task: {task}.")
 
-    date = datetime.now().strftime("%d-%m-%Y")
-    machine_name = socket.gethostname()
-    total_time = end - start
-    total_samples = batch_size * loop_count
+    metrics = calculate_performance_metrics(end - start, batch_size, loop_count)
+    metadata = get_benchmark_metadata()
 
-    samples_per_sec = total_samples / total_time
     full_model_name = "EfficientNet Torch-XLA B0"
-    model_type = "Classification"
-    if task == "classification":
-        model_type += ", ImageNet-1K"
-        dataset_name = "ImageNet-1K"
-    elif task == "na":
-        model_type += ", Random Input Data"
-        dataset_name = full_model_name + ", Random Data"
-    else:
-        raise ValueError(f"Unsupported task: {task}.")
-    num_layers = 82  # Number of layers in the model, in this case number of convolutional layers
+    model_type, dataset_name = determine_model_type_and_dataset(task, full_model_name)
+    num_layers = 82
 
-    print("====================================================================")
-    print("| EfficientNet Torch-XLA Benchmark Results:                       |")
-    print("--------------------------------------------------------------------")
-    print(f"| Model: {full_model_name}")
-    print(f"| Model type: {model_type}")
-    print(f"| Dataset name: {dataset_name}")
-    print(f"| Date: {date}")
-    print(f"| Machine name: {machine_name}")
-    print(f"| Total execution time: {total_time}")
-    print(f"| Total samples: {total_samples}")
-    print(f"| Sample per second: {samples_per_sec}")
+    # Create custom measurements for CPU FPS
+    custom_measurements = [
+        {
+            "measurement_name": "cpu_fps",
+            "value": cpu_fps,
+            "target": -1,
+        }
+    ]
+
+    print_benchmark_results(
+        model_title="EfficientNet Torch-XLA",
+        full_model_name=full_model_name,
+        model_type=model_type,
+        dataset_name=dataset_name,
+        date=metadata["date"],
+        machine_name=metadata["machine_name"],
+        total_time=metrics["total_time"],
+        total_samples=metrics["total_samples"],
+        samples_per_sec=metrics["samples_per_sec"],
+        evaluation_score=evaluation_score,
+        batch_size=batch_size,
+        data_format=data_format,
+        input_size=input_size,
+        channel_size=channel_size,
+    )
+
+    # Add CPU FPS to the print output manually since it's not in the print function yet
     print(f"| CPU samples per second: {cpu_fps}")
-    print(f"| Evaluation score: {evaluation_score}")
-    print(f"| Batch size: {batch_size}")
-    print(f"| Data format: {data_format}")
-    print(f"| Input size: {input_size}")
-    print(f"| Channel size: {channel_size}")
-    print("====================================================================")
 
-    result = {
-        "model": full_model_name,
-        "model_type": model_type,
-        "run_type": f"{'_'.join(full_model_name.split())}_{batch_size}_{'_'.join([str(dim) for dim in input_size])}_{num_layers}_{loop_count}",
-        "config": {
-            "model_size": "small",
-            "torch_xla_enabled": True,
-            "openxla_backend": True,
-            "optimizer_enabled": OPTIMIZER_ENABLED,
-            "program_cache_enabled": PROGRAM_CACHE_ENABLED,
-            "memory_layout_analysis_enabled": MEMORY_LAYOUT_ANALYSIS_ENABLED,
-            "trace_enabled": TRACE_ENABLED,
-        },
-        "num_layers": num_layers,
-        "batch_size": batch_size,
-        "precision": data_format,
-        "dataset_name": dataset_name,
-        "profile_name": "",
-        "input_sequence_length": -1,  # When this value is negative, it means it is not applicable
-        "output_sequence_length": -1,  # When this value is negative, it means it is not applicable
-        "image_dimension": f"{channel_size}x{input_size[0]}x{input_size[1]}",
-        "perf_analysis": False,
-        "training": training,
-        "measurements": [
-            {
-                "iteration": 1,  # This is the number of iterations, we are running only one iteration.
-                "step_name": full_model_name,
-                "step_warm_up_num_iterations": 0,
-                "measurement_name": "total_samples",
-                "value": total_samples,
-                "target": -1,  # This value is negative, because we don't have a target value.
-                "device_power": -1.0,  # This value is negative, because we don't have a device power value.
-                "device_temperature": -1.0,  # This value is negative, because we don't have a device temperature value.
-            },
-            {
-                "iteration": 1,  # This is the number of iterations, we are running only one iteration.
-                "step_name": full_model_name,
-                "step_warm_up_num_iterations": 0,
-                "measurement_name": "total_time",
-                "value": total_time,
-                "target": -1,  # This value is negative, because we don't have a target value.
-                "device_power": -1.0,  # This value is negative, because we don't have a device power value.
-                "device_temperature": -1.0,  # This value is negative, because we don't have a device temperature value.
-            },
-            {
-                "iteration": 1,  # This is the number of iterations, we are running only one iteration.
-                "step_name": full_model_name,
-                "step_warm_up_num_iterations": 0,
-                "measurement_name": "evaluation_score",
-                "value": evaluation_score,
-                "target": -1,
-                "device_power": -1.0,  # This value is negative, because we don't have a device power value.
-                "device_temperature": -1.0,  # This value is negative, because we don't have a device temperature value.
-            },
-            {
-                "iteration": 1,  # This is the number of iterations, we are running only one iteration.
-                "step_name": full_model_name,
-                "step_warm_up_num_iterations": 0,
-                "measurement_name": "cpu_fps",
-                "value": cpu_fps,
-                "target": -1,  # This is the target evaluation score.
-                "device_power": -1.0,  # This value is negative, because we don't have a device power value.
-                "device_temperature": -1.0,  # This value is negative, because we don't have a device temperature value.
-            },
-        ],
-        "device_info": {
-            "device_name": "",
-            "galaxy": False,
-            "arch": "",
-            "chips": 1,
-        },
-        "device_ip": None,
-    }
+    result = create_benchmark_result(
+        full_model_name=full_model_name,
+        model_type=model_type,
+        dataset_name=dataset_name,
+        num_layers=num_layers,
+        batch_size=batch_size,
+        input_size=input_size,
+        loop_count=loop_count,
+        data_format=data_format,
+        training=training,
+        total_time=metrics["total_time"],
+        total_samples=metrics["total_samples"],
+        evaluation_score=evaluation_score,
+        custom_measurements=custom_measurements,
+        optimizer_enabled=OPTIMIZER_ENABLED,
+        program_cache_enabled=PROGRAM_CACHE_ENABLED,
+        memory_layout_analysis_enabled=MEMORY_LAYOUT_ANALYSIS_ENABLED,
+        trace_enabled=TRACE_ENABLED,
+        torch_xla_enabled=True,
+        openxla_backend=True,
+        channel_size=channel_size,
+    )
 
     return result
 

--- a/benchmark/tt-xla/efficientnet.py
+++ b/benchmark/tt-xla/efficientnet.py
@@ -19,7 +19,6 @@ from third_party.tt_forge_models.efficientnet.pytorch.loader import (
     ModelVariant as EfficientNetVariant,
 )
 from .utils import (
-    calculate_performance_metrics,
     get_benchmark_metadata,
     determine_model_type_and_dataset,
     print_benchmark_results,
@@ -103,7 +102,9 @@ def test_efficientnet_torch_xla(
         inputs = [item.to(torch.bfloat16) for item in inputs]
 
     # Load model using tt_forge_models
-    efficientnet_loader = EfficientNetLoader(EfficientNetVariant.TIMM_EFFICIENTNET_B0)
+    model_variant = EfficientNetVariant.TIMM_EFFICIENTNET_B0
+    efficientnet_loader = EfficientNetLoader(model_variant)
+    model_info = efficientnet_loader.get_model_info(model_variant).name
     framework_model: nn.Module = efficientnet_loader.load_model()
 
     if data_format == "bfloat16":
@@ -162,7 +163,10 @@ def test_efficientnet_torch_xla(
     else:
         raise ValueError(f"Unsupported task: {task}.")
 
-    metrics = calculate_performance_metrics(end - start, batch_size, loop_count)
+    total_time = end - start
+    total_samples = batch_size * loop_count
+    samples_per_sec = total_samples / total_time
+
     metadata = get_benchmark_metadata()
 
     full_model_name = "EfficientNet Torch-XLA B0"
@@ -185,18 +189,16 @@ def test_efficientnet_torch_xla(
         dataset_name=dataset_name,
         date=metadata["date"],
         machine_name=metadata["machine_name"],
-        total_time=metrics["total_time"],
-        total_samples=metrics["total_samples"],
-        samples_per_sec=metrics["samples_per_sec"],
+        total_time=total_time,
+        total_samples=total_samples,
+        samples_per_sec=samples_per_sec,
+        cpu_samples_per_sec=cpu_fps,
         evaluation_score=evaluation_score,
         batch_size=batch_size,
         data_format=data_format,
         input_size=input_size,
         channel_size=channel_size,
     )
-
-    # Add CPU FPS to the print output manually since it's not in the print function yet
-    print(f"| CPU samples per second: {cpu_fps}")
 
     result = create_benchmark_result(
         full_model_name=full_model_name,
@@ -208,14 +210,15 @@ def test_efficientnet_torch_xla(
         loop_count=loop_count,
         data_format=data_format,
         training=training,
-        total_time=metrics["total_time"],
-        total_samples=metrics["total_samples"],
+        total_time=total_time,
+        total_samples=total_samples,
         evaluation_score=evaluation_score,
         custom_measurements=custom_measurements,
         optimizer_enabled=OPTIMIZER_ENABLED,
         program_cache_enabled=PROGRAM_CACHE_ENABLED,
         memory_layout_analysis_enabled=MEMORY_LAYOUT_ANALYSIS_ENABLED,
         trace_enabled=TRACE_ENABLED,
+        model_info=model_info,
         torch_xla_enabled=True,
         openxla_backend=True,
         channel_size=channel_size,

--- a/benchmark/tt-xla/mobilenetv2.py
+++ b/benchmark/tt-xla/mobilenetv2.py
@@ -19,7 +19,6 @@ from third_party.tt_forge_models.mobilenetv2.pytorch.loader import (
     ModelVariant as MobileNetV2Variant,
 )
 from .utils import (
-    calculate_performance_metrics,
     get_benchmark_metadata,
     determine_model_type_and_dataset,
     print_benchmark_results,
@@ -103,7 +102,9 @@ def test_mobilenetv2_torch_xla(
         inputs = [item.to(torch.bfloat16) for item in inputs]
 
     # Load model using tt_forge_models
-    mobilenet_loader = MobileNetV2Loader(MobileNetV2Variant.MOBILENET_V2_TORCH_HUB)
+    model_variant = MobileNetV2Variant.MOBILENET_V2_TORCH_HUB
+    mobilenet_loader = MobileNetV2Loader(model_variant)
+    model_info = mobilenet_loader.get_model_info(model_variant).name
     framework_model: nn.Module = mobilenet_loader.load_model()
 
     if data_format == "bfloat16":
@@ -166,7 +167,10 @@ def test_mobilenetv2_torch_xla(
     else:
         raise ValueError(f"Unsupported task: {task}.")
 
-    metrics = calculate_performance_metrics(end - start, batch_size, loop_count)
+    total_time = end - start
+    total_samples = batch_size * loop_count
+    samples_per_sec = total_samples / total_time
+
     metadata = get_benchmark_metadata()
 
     full_model_name = "MobileNet V2 Torch-XLA"
@@ -189,18 +193,16 @@ def test_mobilenetv2_torch_xla(
         dataset_name=dataset_name,
         date=metadata["date"],
         machine_name=metadata["machine_name"],
-        total_time=metrics["total_time"],
-        total_samples=metrics["total_samples"],
-        samples_per_sec=metrics["samples_per_sec"],
+        total_time=total_time,
+        total_samples=total_samples,
+        samples_per_sec=samples_per_sec,
+        cpu_samples_per_sec=cpu_fps,
         evaluation_score=evaluation_score,
         batch_size=batch_size,
         data_format=data_format,
         input_size=input_size,
         channel_size=channel_size,
     )
-
-    # Add CPU FPS to the print output manually since it's not in the print function yet
-    print(f"| CPU samples per second: {cpu_fps}")
 
     result = create_benchmark_result(
         full_model_name=full_model_name,
@@ -212,14 +214,15 @@ def test_mobilenetv2_torch_xla(
         loop_count=loop_count,
         data_format=data_format,
         training=training,
-        total_time=metrics["total_time"],
-        total_samples=metrics["total_samples"],
+        total_time=total_time,
+        total_samples=total_samples,
         evaluation_score=evaluation_score,
         custom_measurements=custom_measurements,
         optimizer_enabled=OPTIMIZER_ENABLED,
         program_cache_enabled=PROGRAM_CACHE_ENABLED,
         memory_layout_analysis_enabled=MEMORY_LAYOUT_ANALYSIS_ENABLED,
         trace_enabled=TRACE_ENABLED,
+        model_info=model_info,
         torch_xla_enabled=True,
         openxla_backend=True,
         channel_size=channel_size,

--- a/benchmark/tt-xla/resnet.py
+++ b/benchmark/tt-xla/resnet.py
@@ -5,9 +5,7 @@
 # Built-in modules
 import os
 import time
-import socket
 import pytest
-from datetime import datetime
 
 # Third-party modules
 import torch
@@ -17,6 +15,13 @@ from tqdm import tqdm
 
 from benchmark.utils import load_benchmark_dataset, evaluate_classification, measure_cpu_fps
 from third_party.tt_forge_models.resnet.pytorch.loader import ModelLoader as ResNetLoader, ModelVariant as ResNetVariant
+from .utils import (
+    calculate_performance_metrics,
+    get_benchmark_metadata,
+    determine_model_type_and_dataset,
+    print_benchmark_results,
+    create_benchmark_result,
+)
 
 os.environ["PJRT_DEVICE"] = "TT"
 os.environ["XLA_STABLEHLO_COMPILE"] = "1"
@@ -79,8 +84,6 @@ def test_resnet_torch_xla(
     PROGRAM_CACHE_ENABLED = False
     MEMORY_LAYOUT_ANALYSIS_ENABLED = False
     TRACE_ENABLED = False
-
-    module_name = "ResNetTorchXLA"
 
     if task == "classification":
         inputs, labels = load_benchmark_dataset(
@@ -166,116 +169,64 @@ def test_resnet_torch_xla(
     else:
         raise ValueError(f"Unsupported task: {task}.")
 
-    date = datetime.now().strftime("%d-%m-%Y")
-    machine_name = socket.gethostname()
-    total_time = end - start
-    total_samples = batch_size * loop_count
+    metrics = calculate_performance_metrics(end - start, batch_size, loop_count)
+    metadata = get_benchmark_metadata()
 
-    samples_per_sec = total_samples / total_time
     full_model_name = "ResNet Torch-XLA 50"
-    model_type = "Classification"
-    if task == "classification":
-        model_type += ", ImageNet-1K"
-        dataset_name = "ImageNet-1K"
-    elif task == "na":
-        model_type += ", Random Input Data"
-        dataset_name = full_model_name + ", Random Data"
-    else:
-        raise ValueError(f"Unsupported task: {task}.")
-    num_layers = 50  # Number of layers in the model
+    model_type, dataset_name = determine_model_type_and_dataset(task, full_model_name)
+    num_layers = 50
 
-    print("====================================================================")
-    print("| ResNet Torch-XLA Benchmark Results:                             |")
-    print("--------------------------------------------------------------------")
-    print(f"| Model: {full_model_name}")
-    print(f"| Model type: {model_type}")
-    print(f"| Dataset name: {dataset_name}")
-    print(f"| Date: {date}")
-    print(f"| Machine name: {machine_name}")
-    print(f"| Total execution time: {total_time}")
-    print(f"| Total samples: {total_samples}")
-    print(f"| Sample per second: {samples_per_sec}")
+    # Create custom measurements for CPU FPS
+    custom_measurements = [
+        {
+            "measurement_name": "cpu_fps",
+            "value": cpu_fps,
+            "target": -1,
+        }
+    ]
+
+    print_benchmark_results(
+        model_title="ResNet Torch-XLA",
+        full_model_name=full_model_name,
+        model_type=model_type,
+        dataset_name=dataset_name,
+        date=metadata["date"],
+        machine_name=metadata["machine_name"],
+        total_time=metrics["total_time"],
+        total_samples=metrics["total_samples"],
+        samples_per_sec=metrics["samples_per_sec"],
+        evaluation_score=evaluation_score,
+        batch_size=batch_size,
+        data_format=data_format,
+        input_size=input_size,
+        channel_size=channel_size,
+    )
+
+    # Add CPU FPS to the print output manually since it's not in the print function yet
     print(f"| CPU samples per second: {cpu_fps}")
-    print(f"| Evaluation score: {evaluation_score}")
-    print(f"| Batch size: {batch_size}")
-    print(f"| Data format: {data_format}")
-    print(f"| Input size: {input_size}")
-    print(f"| Channel size: {channel_size}")
-    print("====================================================================")
 
-    result = {
-        "model": full_model_name,
-        "model_type": model_type,
-        "run_type": f"{'_'.join(full_model_name.split())}_{batch_size}_{'_'.join([str(dim) for dim in input_size])}_{num_layers}_{loop_count}",
-        "config": {
-            "model_size": "small",
-            "torch_xla_enabled": True,
-            "openxla_backend": True,
-            "optimizer_enabled": OPTIMIZER_ENABLED,
-            "program_cache_enabled": PROGRAM_CACHE_ENABLED,
-            "memory_layout_analysis_enabled": MEMORY_LAYOUT_ANALYSIS_ENABLED,
-            "trace_enabled": TRACE_ENABLED,
-        },
-        "num_layers": num_layers,
-        "batch_size": batch_size,
-        "precision": data_format,
-        "dataset_name": dataset_name,
-        "profile_name": "",
-        "input_sequence_length": -1,  # When this value is negative, it means it is not applicable
-        "output_sequence_length": -1,  # When this value is negative, it means it is not applicable
-        "image_dimension": f"{channel_size}x{input_size[0]}x{input_size[1]}",
-        "perf_analysis": False,
-        "training": training,
-        "measurements": [
-            {
-                "iteration": 1,  # This is the number of iterations, we are running only one iteration.
-                "step_name": full_model_name,
-                "step_warm_up_num_iterations": 0,
-                "measurement_name": "total_samples",
-                "value": total_samples,
-                "target": -1,  # This value is negative, because we don't have a target value.
-                "device_power": -1.0,  # This value is negative, because we don't have a device power value.
-                "device_temperature": -1.0,  # This value is negative, because we don't have a device temperature value.
-            },
-            {
-                "iteration": 1,  # This is the number of iterations, we are running only one iteration.
-                "step_name": full_model_name,
-                "step_warm_up_num_iterations": 0,
-                "measurement_name": "total_time",
-                "value": total_time,
-                "target": -1,  # This value is negative, because we don't have a target value.
-                "device_power": -1.0,  # This value is negative, because we don't have a device power value.
-                "device_temperature": -1.0,  # This value is negative, because we don't have a device temperature value.
-            },
-            {
-                "iteration": 1,  # This is the number of iterations, we are running only one iteration.
-                "step_name": full_model_name,
-                "step_warm_up_num_iterations": 0,
-                "measurement_name": "evaluation_score",
-                "value": evaluation_score,
-                "target": -1,
-                "device_power": -1.0,  # This value is negative, because we don't have a device power value.
-                "device_temperature": -1.0,  # This value is negative, because we don't have a device temperature value.
-            },
-            {
-                "iteration": 1,  # This is the number of iterations, we are running only one iteration.
-                "step_name": full_model_name,
-                "step_warm_up_num_iterations": 0,
-                "measurement_name": "cpu_fps",
-                "value": cpu_fps,
-                "target": -1,  # This is the target evaluation score.
-                "device_power": -1.0,  # This value is negative, because we don't have a device power value.
-                "device_temperature": -1.0,  # This value is negative, because we don't have a device temperature value.
-            },
-        ],
-        "device_info": {
-            "device_name": "",
-            "galaxy": False,
-            "arch": "",
-            "chips": 1,
-        },
-        "device_ip": None,
-    }
+    result = create_benchmark_result(
+        full_model_name=full_model_name,
+        model_type=model_type,
+        dataset_name=dataset_name,
+        num_layers=num_layers,
+        batch_size=batch_size,
+        input_size=input_size,
+        loop_count=loop_count,
+        data_format=data_format,
+        training=training,
+        total_time=metrics["total_time"],
+        total_samples=metrics["total_samples"],
+        evaluation_score=evaluation_score,
+        custom_measurements=custom_measurements,
+        optimizer_enabled=OPTIMIZER_ENABLED,
+        program_cache_enabled=PROGRAM_CACHE_ENABLED,
+        memory_layout_analysis_enabled=MEMORY_LAYOUT_ANALYSIS_ENABLED,
+        trace_enabled=TRACE_ENABLED,
+        torch_xla_enabled=True,
+        openxla_backend=True,
+        channel_size=channel_size,
+    )
 
     return result
 

--- a/benchmark/tt-xla/resnet.py
+++ b/benchmark/tt-xla/resnet.py
@@ -16,7 +16,6 @@ from tqdm import tqdm
 from benchmark.utils import load_benchmark_dataset, evaluate_classification, measure_cpu_fps
 from third_party.tt_forge_models.resnet.pytorch.loader import ModelLoader as ResNetLoader, ModelVariant as ResNetVariant
 from .utils import (
-    calculate_performance_metrics,
     get_benchmark_metadata,
     determine_model_type_and_dataset,
     print_benchmark_results,
@@ -106,7 +105,9 @@ def test_resnet_torch_xla(
         inputs = [item.to(torch.bfloat16) for item in inputs]
 
     # Load model using tt_forge_models
-    resnet_loader = ResNetLoader(ResNetVariant.RESNET_50_HF)
+    model_variant = ResNetVariant.RESNET_50_HF
+    resnet_loader = ResNetLoader(model_variant)
+    model_info = resnet_loader.get_model_info(model_variant).name
     framework_model: nn.Module = resnet_loader.load_model()
 
     if data_format == "bfloat16":
@@ -169,7 +170,10 @@ def test_resnet_torch_xla(
     else:
         raise ValueError(f"Unsupported task: {task}.")
 
-    metrics = calculate_performance_metrics(end - start, batch_size, loop_count)
+    total_time = end - start
+    total_samples = batch_size * loop_count
+    samples_per_sec = total_samples / total_time
+
     metadata = get_benchmark_metadata()
 
     full_model_name = "ResNet Torch-XLA 50"
@@ -192,18 +196,16 @@ def test_resnet_torch_xla(
         dataset_name=dataset_name,
         date=metadata["date"],
         machine_name=metadata["machine_name"],
-        total_time=metrics["total_time"],
-        total_samples=metrics["total_samples"],
-        samples_per_sec=metrics["samples_per_sec"],
+        total_time=total_time,
+        total_samples=total_samples,
+        samples_per_sec=samples_per_sec,
+        cpu_samples_per_sec=cpu_fps,
         evaluation_score=evaluation_score,
         batch_size=batch_size,
         data_format=data_format,
         input_size=input_size,
         channel_size=channel_size,
     )
-
-    # Add CPU FPS to the print output manually since it's not in the print function yet
-    print(f"| CPU samples per second: {cpu_fps}")
 
     result = create_benchmark_result(
         full_model_name=full_model_name,
@@ -215,14 +217,15 @@ def test_resnet_torch_xla(
         loop_count=loop_count,
         data_format=data_format,
         training=training,
-        total_time=metrics["total_time"],
-        total_samples=metrics["total_samples"],
+        total_time=total_time,
+        total_samples=total_samples,
         evaluation_score=evaluation_score,
         custom_measurements=custom_measurements,
         optimizer_enabled=OPTIMIZER_ENABLED,
         program_cache_enabled=PROGRAM_CACHE_ENABLED,
         memory_layout_analysis_enabled=MEMORY_LAYOUT_ANALYSIS_ENABLED,
         trace_enabled=TRACE_ENABLED,
+        model_info=model_info,
         torch_xla_enabled=True,
         openxla_backend=True,
         channel_size=channel_size,

--- a/benchmark/tt-xla/utils.py
+++ b/benchmark/tt-xla/utils.py
@@ -7,18 +7,6 @@ from datetime import datetime
 from typing import Dict, Any, Optional, List
 
 
-def calculate_performance_metrics(total_time: float, batch_size: int, loop_count: int) -> Dict[str, Any]:
-    """Calculate basic performance metrics."""
-    total_samples = batch_size * loop_count
-    samples_per_sec = total_samples / total_time
-
-    return {
-        "total_time": total_time,
-        "total_samples": total_samples,
-        "samples_per_sec": samples_per_sec,
-    }
-
-
 def get_benchmark_metadata() -> Dict[str, str]:
     """Get common benchmark metadata."""
     return {
@@ -53,6 +41,7 @@ def print_benchmark_results(
     total_time: float,
     total_samples: int,
     samples_per_sec: float,
+    cpu_samples_per_sec: Optional[float] = None,
     evaluation_score: Optional[float] = None,
     batch_size: int = None,
     data_format: str = None,
@@ -71,6 +60,9 @@ def print_benchmark_results(
     print(f"| Total execution time: {total_time}")
     print(f"| Total samples: {total_samples}")
     print(f"| Sample per second: {samples_per_sec}")
+
+    if cpu_samples_per_sec is not None:
+        print(f"| CPU samples per second: {cpu_samples_per_sec}")
 
     if evaluation_score is not None:
         print(f"| Evaluation score: {evaluation_score}")
@@ -131,6 +123,7 @@ def create_benchmark_result(
     program_cache_enabled: bool = False,
     memory_layout_analysis_enabled: bool = False,
     trace_enabled: bool = False,
+    model_info: str = "",
     torch_xla_enabled: bool = True,
     openxla_backend: bool = True,
     channel_size: int = 3,
@@ -138,7 +131,6 @@ def create_benchmark_result(
     galaxy: bool = False,
     arch: str = "",
     chips: int = 1,
-    device_ip: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Create a standardized benchmark result dictionary.
 
@@ -183,6 +175,7 @@ def create_benchmark_result(
         "program_cache_enabled": program_cache_enabled,
         "memory_layout_analysis_enabled": memory_layout_analysis_enabled,
         "trace_enabled": trace_enabled,
+        "model_info": model_info,
     }
 
     if torch_xla_enabled:
@@ -215,5 +208,4 @@ def create_benchmark_result(
             "arch": arch,
             "chips": chips,
         },
-        "device_ip": device_ip,
     }

--- a/benchmark/tt-xla/utils.py
+++ b/benchmark/tt-xla/utils.py
@@ -1,0 +1,219 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import socket
+from datetime import datetime
+from typing import Dict, Any, Optional, List
+
+
+def calculate_performance_metrics(total_time: float, batch_size: int, loop_count: int) -> Dict[str, Any]:
+    """Calculate basic performance metrics."""
+    total_samples = batch_size * loop_count
+    samples_per_sec = total_samples / total_time
+
+    return {
+        "total_time": total_time,
+        "total_samples": total_samples,
+        "samples_per_sec": samples_per_sec,
+    }
+
+
+def get_benchmark_metadata() -> Dict[str, str]:
+    """Get common benchmark metadata."""
+    return {
+        "date": datetime.now().strftime("%d-%m-%Y"),
+        "machine_name": socket.gethostname(),
+    }
+
+
+def determine_model_type_and_dataset(task: str, full_model_name: str) -> tuple[str, str]:
+    """Determine model type and dataset name based on task."""
+    model_type = "Classification"
+
+    if task == "classification":
+        model_type += ", ImageNet-1K"
+        dataset_name = "ImageNet-1K"
+    elif task == "na":
+        model_type += ", Random Input Data"
+        dataset_name = full_model_name + ", Random Data"
+    else:
+        raise ValueError(f"Unsupported task: {task}.")
+
+    return model_type, dataset_name
+
+
+def print_benchmark_results(
+    model_title: str,
+    full_model_name: str,
+    model_type: str,
+    dataset_name: str,
+    date: str,
+    machine_name: str,
+    total_time: float,
+    total_samples: int,
+    samples_per_sec: float,
+    evaluation_score: Optional[float] = None,
+    batch_size: int = None,
+    data_format: str = None,
+    input_size: tuple = None,
+    channel_size: int = None,
+) -> None:
+    """Print formatted benchmark results."""
+    print("====================================================================")
+    print(f"| {model_title} Benchmark Results:".ljust(67) + "|")
+    print("--------------------------------------------------------------------")
+    print(f"| Model: {full_model_name}")
+    print(f"| Model type: {model_type}")
+    print(f"| Dataset name: {dataset_name}")
+    print(f"| Date: {date}")
+    print(f"| Machine name: {machine_name}")
+    print(f"| Total execution time: {total_time}")
+    print(f"| Total samples: {total_samples}")
+    print(f"| Sample per second: {samples_per_sec}")
+
+    if evaluation_score is not None:
+        print(f"| Evaluation score: {evaluation_score}")
+
+    if batch_size is not None:
+        print(f"| Batch size: {batch_size}")
+
+    if data_format is not None:
+        print(f"| Data format: {data_format}")
+
+    if input_size is not None:
+        print(f"| Input size: {input_size}")
+
+    if channel_size is not None:
+        print(f"| Channel size: {channel_size}")
+
+    print("====================================================================")
+
+
+def create_measurement(
+    measurement_name: str,
+    value: Any,
+    step_name: str,
+    iteration: int = 1,
+    step_warm_up_num_iterations: int = 0,
+    target: float = -1,
+    device_power: float = -1.0,
+    device_temperature: float = -1.0,
+) -> Dict[str, Any]:
+    """Create a single measurement dictionary."""
+    return {
+        "iteration": iteration,
+        "step_name": step_name,
+        "step_warm_up_num_iterations": step_warm_up_num_iterations,
+        "measurement_name": measurement_name,
+        "value": value,
+        "target": target,
+        "device_power": device_power,
+        "device_temperature": device_temperature,
+    }
+
+
+def create_benchmark_result(
+    full_model_name: str,
+    model_type: str,
+    dataset_name: str,
+    num_layers: int,
+    batch_size: int,
+    input_size: tuple,
+    loop_count: int,
+    data_format: str,
+    training: bool,
+    total_time: float,
+    total_samples: int,
+    evaluation_score: Optional[float] = None,
+    custom_measurements: Optional[List[Dict[str, Any]]] = None,
+    optimizer_enabled: bool = False,
+    program_cache_enabled: bool = False,
+    memory_layout_analysis_enabled: bool = False,
+    trace_enabled: bool = False,
+    torch_xla_enabled: bool = True,
+    openxla_backend: bool = True,
+    channel_size: int = 3,
+    device_name: str = "",
+    galaxy: bool = False,
+    arch: str = "",
+    chips: int = 1,
+    device_ip: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Create a standardized benchmark result dictionary.
+
+    Args:
+        custom_measurements: List of additional measurement dictionaries to include.
+                           Each measurement should have keys: measurement_name, value, and optionally
+                           iteration, step_name, step_warm_up_num_iterations, target, device_power, device_temperature
+    """
+    # Create standard measurements
+    measurements = [
+        create_measurement("total_samples", total_samples, full_model_name),
+        create_measurement("total_time", total_time, full_model_name),
+    ]
+
+    # Add evaluation score if provided
+    if evaluation_score is not None:
+        measurements.append(create_measurement("evaluation_score", evaluation_score, full_model_name))
+
+    # Add custom measurements if provided
+    if custom_measurements:
+        for custom_measurement in custom_measurements:
+            # Ensure required fields are present
+            if "measurement_name" not in custom_measurement or "value" not in custom_measurement:
+                raise ValueError("Custom measurements must include 'measurement_name' and 'value' fields")
+
+            # Fill in default values for missing fields
+            measurement = {
+                "iteration": custom_measurement.get("iteration", 1),
+                "step_name": custom_measurement.get("step_name", full_model_name),
+                "step_warm_up_num_iterations": custom_measurement.get("step_warm_up_num_iterations", 0),
+                "measurement_name": custom_measurement["measurement_name"],
+                "value": custom_measurement["value"],
+                "target": custom_measurement.get("target", -1),
+                "device_power": custom_measurement.get("device_power", -1.0),
+                "device_temperature": custom_measurement.get("device_temperature", -1.0),
+            }
+            measurements.append(measurement)
+
+    config = {
+        "model_size": "small",
+        "optimizer_enabled": optimizer_enabled,
+        "program_cache_enabled": program_cache_enabled,
+        "memory_layout_analysis_enabled": memory_layout_analysis_enabled,
+        "trace_enabled": trace_enabled,
+    }
+
+    if torch_xla_enabled:
+        config.update(
+            {
+                "torch_xla_enabled": torch_xla_enabled,
+                "openxla_backend": openxla_backend,
+            }
+        )
+
+    return {
+        "model": full_model_name,
+        "model_type": model_type,
+        "run_type": f"{'_'.join(full_model_name.split())}_{batch_size}_{'_'.join([str(dim) for dim in input_size])}_{num_layers}_{loop_count}",
+        "config": config,
+        "num_layers": num_layers,
+        "batch_size": batch_size,
+        "precision": data_format,
+        "dataset_name": dataset_name,
+        "profile_name": "",
+        "input_sequence_length": -1,
+        "output_sequence_length": -1,
+        "image_dimension": f"{channel_size}x{input_size[0]}x{input_size[1]}",
+        "perf_analysis": False,
+        "training": training,
+        "measurements": measurements,
+        "device_info": {
+            "device_name": device_name,
+            "galaxy": galaxy,
+            "arch": arch,
+            "chips": chips,
+        },
+        "device_ip": device_ip,
+    }

--- a/benchmark/tt-xla/vovnet.py
+++ b/benchmark/tt-xla/vovnet.py
@@ -5,9 +5,7 @@
 # Built-in modules
 import os
 import time
-import socket
 import pytest
-from datetime import datetime
 
 # Third-party modules
 import torch
@@ -17,6 +15,13 @@ from tqdm import tqdm
 
 from benchmark.utils import load_benchmark_dataset, evaluate_classification, measure_cpu_fps
 from third_party.tt_forge_models.vovnet.pytorch.loader import ModelLoader as VovNetLoader, ModelVariant as VovNetVariant
+from .utils import (
+    calculate_performance_metrics,
+    get_benchmark_metadata,
+    determine_model_type_and_dataset,
+    print_benchmark_results,
+    create_benchmark_result,
+)
 
 os.environ["PJRT_DEVICE"] = "TT"
 os.environ["XLA_STABLEHLO_COMPILE"] = "1"
@@ -87,8 +92,6 @@ def test_vovnet_torch_xla(
     PROGRAM_CACHE_ENABLED = False
     MEMORY_LAYOUT_ANALYSIS_ENABLED = False
     TRACE_ENABLED = False
-
-    module_name = "VovnetTorchXLA"
 
     if task == "classification":
         inputs, labels = load_benchmark_dataset(
@@ -167,116 +170,64 @@ def test_vovnet_torch_xla(
     else:
         raise ValueError(f"Unsupported task: {task}")
 
-    date = datetime.now().strftime("%d-%m-%Y")
-    machine_name = socket.gethostname()
-    total_time = end - start
-    total_samples = batch_size * loop_count
+    metrics = calculate_performance_metrics(end - start, batch_size, loop_count)
+    metadata = get_benchmark_metadata()
 
-    samples_per_sec = total_samples / total_time
     full_model_name = "VoVNet Torch-XLA"
-    model_type = "Classification"
-    if task == "classification":
-        model_type += ", ImageNet-1K"
-        dataset_name = "ImageNet-1K"
-    elif task == "na":
-        model_type += ", Random Input Data"
-        dataset_name = full_model_name + ", Random Data"
-    else:
-        raise ValueError(f"Unsupported task: {task}")
-    num_layers = -1  # Number of layers varies by variant
+    model_type, dataset_name = determine_model_type_and_dataset(task, full_model_name)
+    num_layers = -1
 
-    print("====================================================================")
-    print("| VoVNet Torch-XLA Benchmark Results:                             |")
-    print("--------------------------------------------------------------------")
-    print(f"| Model: {full_model_name}")
-    print(f"| Model type: {model_type}")
-    print(f"| Dataset name: {dataset_name}")
-    print(f"| Date: {date}")
-    print(f"| Machine name: {machine_name}")
-    print(f"| Total execution time: {total_time}")
-    print(f"| Total samples: {total_samples}")
-    print(f"| Sample per second: {samples_per_sec}")
+    # Create custom measurements for CPU FPS
+    custom_measurements = [
+        {
+            "measurement_name": "cpu_fps",
+            "value": cpu_fps,
+            "target": -1,
+        }
+    ]
+
+    print_benchmark_results(
+        model_title="VoVNet Torch-XLA",
+        full_model_name=full_model_name,
+        model_type=model_type,
+        dataset_name=dataset_name,
+        date=metadata["date"],
+        machine_name=metadata["machine_name"],
+        total_time=metrics["total_time"],
+        total_samples=metrics["total_samples"],
+        samples_per_sec=metrics["samples_per_sec"],
+        evaluation_score=evaluation_score,
+        batch_size=batch_size,
+        data_format=data_format,
+        input_size=input_size,
+        channel_size=channel_size,
+    )
+
+    # Add CPU FPS to the print output manually since it's not in the print function yet
     print(f"| CPU samples per second: {cpu_fps}")
-    print(f"| Evaluation score: {evaluation_score}")
-    print(f"| Batch size: {batch_size}")
-    print(f"| Data format: {data_format}")
-    print(f"| Input size: {input_size}")
-    print(f"| Channel size: {channel_size}")
-    print("====================================================================")
 
-    result = {
-        "model": full_model_name,
-        "model_type": model_type,
-        "run_type": f"{'_'.join(full_model_name.split())}_{batch_size}_{'_'.join([str(dim) for dim in input_size])}_{loop_count}",
-        "config": {
-            "model_size": "small",
-            "torch_xla_enabled": True,
-            "openxla_backend": True,
-            "optimizer_enabled": OPTIMIZER_ENABLED,
-            "program_cache_enabled": PROGRAM_CACHE_ENABLED,
-            "memory_layout_analysis_enabled": MEMORY_LAYOUT_ANALYSIS_ENABLED,
-            "trace_enabled": TRACE_ENABLED,
-        },
-        "num_layers": num_layers,
-        "batch_size": batch_size,
-        "precision": data_format,
-        "dataset_name": dataset_name,
-        "profile_name": "",
-        "input_sequence_length": -1,  # When this value is negative, it means it is not applicable
-        "output_sequence_length": -1,  # When this value is negative, it means it is not applicable
-        "image_dimension": f"{channel_size}x{input_size[0]}x{input_size[1]}",
-        "perf_analysis": False,
-        "training": training,
-        "measurements": [
-            {
-                "iteration": 1,
-                "step_name": full_model_name,
-                "step_warm_up_num_iterations": 0,
-                "measurement_name": "total_samples",
-                "value": total_samples,
-                "target": -1,
-                "device_power": -1.0,
-                "device_temperature": -1.0,
-            },
-            {
-                "iteration": 1,
-                "step_name": full_model_name,
-                "step_warm_up_num_iterations": 0,
-                "measurement_name": "total_time",
-                "value": total_time,
-                "target": -1,
-                "device_power": -1.0,
-                "device_temperature": -1.0,
-            },
-            {
-                "iteration": 1,
-                "step_name": full_model_name,
-                "step_warm_up_num_iterations": 0,
-                "measurement_name": "evaluation_score",
-                "value": evaluation_score,
-                "target": -1,
-                "device_power": -1.0,
-                "device_temperature": -1.0,
-            },
-            {
-                "iteration": 1,  # This is the number of iterations, we are running only one iteration.
-                "step_name": full_model_name,
-                "step_warm_up_num_iterations": 0,
-                "measurement_name": "cpu_fps",
-                "value": cpu_fps,
-                "target": -1,  # This is the target evaluation score.
-                "device_power": -1.0,  # This value is negative, because we don't have a device power value.
-                "device_temperature": -1.0,  # This value is negative, because we don't have a device temperature value.
-            },
-        ],
-        "device_info": {
-            "device_name": "",
-            "galaxy": False,
-            "arch": "",
-            "chips": 1,
-        },
-        "device_ip": None,
-    }
+    result = create_benchmark_result(
+        full_model_name=full_model_name,
+        model_type=model_type,
+        dataset_name=dataset_name,
+        num_layers=num_layers,
+        batch_size=batch_size,
+        input_size=input_size,
+        loop_count=loop_count,
+        data_format=data_format,
+        training=training,
+        total_time=metrics["total_time"],
+        total_samples=metrics["total_samples"],
+        evaluation_score=evaluation_score,
+        custom_measurements=custom_measurements,
+        optimizer_enabled=OPTIMIZER_ENABLED,
+        program_cache_enabled=PROGRAM_CACHE_ENABLED,
+        memory_layout_analysis_enabled=MEMORY_LAYOUT_ANALYSIS_ENABLED,
+        trace_enabled=TRACE_ENABLED,
+        torch_xla_enabled=True,
+        openxla_backend=True,
+        channel_size=channel_size,
+    )
 
     return result
 


### PR DESCRIPTION
- Extracted benchmark utilities (print and result) to `utils.py`.
- Added `model_info` to the result, that contains all the necessary information about the model - framework, name, variant, task and source.
- Changed UNet loading to use tt_forge_models loader.

Refactoring is mentioned in https://github.com/tenstorrent/tt-forge/issues/301, but it will be broken in multiple PRs, this is the initial one.

Closes:
https://github.com/tenstorrent/tt-forge/issues/387

