### PR TITLE
Fix renamed ttxla_tools

### DIFF
--- a/benchmark/tt-xla/resnet_jax.py
+++ b/benchmark/tt-xla/resnet_jax.py
@@ -18,7 +18,7 @@ import jax
 
 from transformers import FlaxResNetForImageClassification
 from jax import device_put
-from ttxla_tools import serialize_function_to_binary
+from tt_jax.tools import serialize_function_to_binary
 
 
 BATCH_SIZE = [


### PR DESCRIPTION
Recently, ttxla_tools are renamed to tt_jax.tools
This is the fix. Successful workflow:
https://github.com/tenstorrent/tt-xla/actions/runs/17459031837/job/49579264841