### PR TITLE
Upgrade python to 3.11 for tt-torch

### DIFF
--- a/.github/Dockerfile.tt-forge-slim
+++ b/.github/Dockerfile.tt-forge-slim
@@ -62,7 +62,7 @@ RUN FRONTEND=tt-forge-fe && \
 
 # Create and activate virtual environment for tt-torch, install whl
 RUN FRONTEND=tt-torch && \
-    python -m venv venv-$FRONTEND && \
+    /usr/bin/python3.11 -m venv venv-$FRONTEND && \
     source venv-$FRONTEND/bin/activate && \
     WHL_VERSION=$(pip index versions $FRONTEND -i https://pypi.eng.aws.tenstorrent.com --pre 2>/dev/null | grep -oP 'Available versions: \K.*' | tr -d ' ' | tr ',' '\n' | grep dev | head -n1) && \
     pip install --no-cache-dir https://pypi.eng.aws.tenstorrent.com/tt-torch/tt_torch-$WHL_VERSION-cp310-cp310-linux_x86_64.whl && \

--- a/.github/actions/set-release-facts/action.yaml
+++ b/.github/actions/set-release-facts/action.yaml
@@ -194,6 +194,7 @@ runs:
             artifact_cleanup_file_glob='*torchvision*'
             artifact_cleanup_folder_glob='*install-artifacts-debug*'
             pip_wheel_names="tt-torch"
+            docker_build_file=".github/Dockerfile.single-wheel-slim-3.11"
         elif [[ "${{ inputs.repo }}" =~ "tt-mlir" ]]; then
             # NOTE: no nightly job current for tt-mlir keeping this here for future use
             workflow="On push"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,7 +132,7 @@ jobs:
         make_latest: false
         force_rebuild: ${{ inputs.overwrite_releases }}
         draft: ${{ inputs.draft }}
-        dockerfile: ${{ inputs.repo_short == 'tt-xla' && '.github/Dockerfile.single-wheel-slim-3.11' || '.github/Dockerfile.single-wheel-slim' }}
+        dockerfile: ${{ (inputs.repo_short == 'tt-xla' || inputs.repo_short == 'tt-torch') && '.github/Dockerfile.single-wheel-slim-3.11' || '.github/Dockerfile.single-wheel-slim' }}
         build_args: "--build-arg REPO_SHORT=${{ steps.set-release-facts.outputs.repo_short }} --build-arg WHEEL_FILES_PATH=${{ steps.build-release-wheel.outputs.wheel_files_path }}"
 
   test-release:


### PR DESCRIPTION
Since this PR is merged:
https://github.com/tenstorrent/tt-torch/pull/1213
Python is upgraded to version 3.11 in tt-torch.
This PR fixes release docker images.