### PR TITLE
Fix tt-xla perf benchmark tests dependency issue

### DIFF
--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -297,7 +297,6 @@ jobs:
         echo "Create perf report directory"
         mkdir -p ${{ steps.strings.outputs.perf_report_path }}
         source /home/forge/venv-${{ matrix.build.project }}/bin/activate
-        pip freeze
 
         if [ "${{ matrix.build.project }}" == "tt-torch" ]; then
           export TT_TORCH_SAVE_MLIR=TTIR


### PR DESCRIPTION
#### Problem
Some tt-xla performance benchmark tests were installing `timm` in the `Install system and python dependencies` step and that caused the `torch` version to be bumped to 2.8.0.
That caused tests to fail because tt-xla wheel requires `torch==2.7.0`.

#### Solution
Specify `torch==2.7.0` in the `Install system and python dependencies` step to ensure that the version won't be changed.