### PR TITLE
add deepwiki badge for forge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/tenstorrent/tt-forge)
+
 <div align="center">
 
 <h1>


### PR DESCRIPTION
https://github.com/tenstorrent/tt-forge/issues/327 

We added TT-Forge to DeepWiki and the badge should be displayed to make developers aware that it's available. 