### PR TITLE
Fix bugs

### DIFF
--- a/.github/Dockerfile.tt-forge-slim
+++ b/.github/Dockerfile.tt-forge-slim
@@ -14,6 +14,7 @@ RUN apt-get update && \
     git \
     vim \
     nano \
+    unzip \
     ca-certificates \
     sudo \
     ssh \

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -212,16 +212,19 @@ jobs:
       run: |
         source /home/forge/venv-${{ matrix.build.project }}/bin/activate
 
-        project_name=$(echo "${{ matrix.build.project }}" | tr "-" "_")
         if [[ "${{ matrix.build.project }}" == "tt-xla" ]]; then
-          project_name="pjrt_plugin_tt"
+          project_name="pjrt-plugin-tt"
+        elif [[ "${{ matrix.build.project }}" == "tt-torch" ]]; then
+          project_name="tt-torch"
+        elif [[ "${{ matrix.build.project }}" == "tt-forge-fe" ]]; then
+          project_name="tt_forge_fe"
         fi
 
         echo "Set version to commit sha if called from other repo"
         if [[ "${{ inputs.update-wheel }}" == "true" || -n "${{ inputs.run_id }}" ]]; then
           version=$(pip freeze | grep -oP "$project_name-.+dev\.\K([^-]*)")
         else
-          version=$(pip freeze | grep -oP "(?<=$project_name-)[^-]+")
+          version=$(pip freeze | grep "$project_name==" | grep -oP '==\K.*')
         fi
 
         echo "Wheel version: $version"

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -220,6 +220,15 @@ jobs:
           project_name="tt_forge_fe"
         fi
 
+        # wheels from docker
+        # pjrt-plugin-tt
+        # tt-torch
+        # tt_forge_fe
+        # wheels updated
+        # pjrt_plugin_tt
+        # tt_torch
+        # tt_forge_fe
+
         echo "Set version to commit sha if called from other repo"
         if [[ "${{ inputs.update-wheel }}" == "true" || -n "${{ inputs.run_id }}" ]]; then
           version=$(pip freeze | grep -oP "$project_name-.+dev\.\K([^-]*)")
@@ -257,7 +266,6 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    # ttrt version (sha) should be taken from release metadata or something
     - name: Download ttrt wheel
       if: ${{ !matrix.build.skip-device-perf }}
       uses: dawidd6/action-download-artifact@v11
@@ -268,6 +276,16 @@ jobs:
         repo: tenstorrent/tt-mlir
         check_artifacts: true
         path: ./
+        skip_unpack: true
+
+    - name: Extract artifacts manually
+      if: ${{ !matrix.build.skip-device-perf }}
+      shell: bash
+      run: |
+        echo "Extracting ttrt wheel"
+        unzip -q ttrt-whl-tracy.zip
+        echo "Extracting install artifacts"
+        unzip -q install-artifacts-tracy.zip
 
     - name: Install ttrt
       shell: bash

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -282,6 +282,8 @@ jobs:
       if: ${{ !matrix.build.skip-device-perf }}
       shell: bash
       run: |
+        apt update
+        apt install unzip
         echo "Extracting ttrt wheel"
         unzip -q ttrt-whl-tracy.zip
         echo "Extracting install artifacts"

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -286,11 +286,14 @@ jobs:
       run: |
         apt update
         apt install unzip
+
         echo "Extracting ttrt wheel"
-        unzip -q ttrt-whl-tracy.zip
+        mkdir ttrt-whl-tracy
+        unzip -q ttrt-whl-tracy/ttrt-whl-tracy.zip -d ttrt-whl-tracy
+
         echo "Extracting install artifacts"
-        unzip -q install-artifacts-tracy.zip
-        ls -la
+        mkdir install-artifacts-tracy
+        unzip -q install-artifacts-tracy/install-artifacts-tracy.zip -d install-artifacts-tracy
 
     - name: Install ttrt
       shell: bash

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -290,6 +290,7 @@ jobs:
         unzip -q ttrt-whl-tracy.zip
         echo "Extracting install artifacts"
         unzip -q install-artifacts-tracy.zip
+        ls -la
 
     - name: Install ttrt
       shell: bash

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -289,10 +289,12 @@ jobs:
 
         echo "Extracting ttrt wheel"
         mkdir ttrt-whl-tracy
+        mv ttrt-whl-tracy.zip ttrt-whl-tracy/ttrt-whl-tracy.zip
         unzip -q ttrt-whl-tracy/ttrt-whl-tracy.zip -d ttrt-whl-tracy
 
         echo "Extracting install artifacts"
         mkdir install-artifacts-tracy
+        mv install-artifacts-tracy.zip install-artifacts-tracy/install-artifacts-tracy.zip
         unzip -q install-artifacts-tracy/install-artifacts-tracy.zip -d install-artifacts-tracy
 
     - name: Install ttrt

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -284,9 +284,6 @@ jobs:
       if: ${{ !matrix.build.skip-device-perf }}
       shell: bash
       run: |
-        apt update
-        apt install unzip
-
         echo "Extracting ttrt wheel"
         mkdir ttrt-whl-tracy
         mv ttrt-whl-tracy.zip ttrt-whl-tracy/ttrt-whl-tracy.zip

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -212,22 +212,24 @@ jobs:
       run: |
         source /home/forge/venv-${{ matrix.build.project }}/bin/activate
 
-        if [[ "${{ matrix.build.project }}" == "tt-xla" ]]; then
-          project_name="pjrt-plugin-tt"
-        elif [[ "${{ matrix.build.project }}" == "tt-torch" ]]; then
-          project_name="tt-torch"
-        elif [[ "${{ matrix.build.project }}" == "tt-forge-fe" ]]; then
-          project_name="tt_forge_fe"
-        fi
+        declare -A raw_wheel_project_names=(
+          ["tt-xla"]="pjrt_plugin_tt"
+          ["tt-torch"]="tt_torch"
+          ["tt-forge-fe"]="tt_forge_fe"
+        )
 
-        # wheels from docker
-        # pjrt-plugin-tt
-        # tt-torch
-        # tt_forge_fe
-        # wheels updated
-        # pjrt_plugin_tt
-        # tt_torch
-        # tt_forge_fe
+        declare -A pypi_wheel_project_names=(
+          ["tt-xla"]="pjrt-plugin-tt"
+          ["tt-torch"]="tt-torch"
+          ["tt-forge-fe"]="tt_forge_fe"
+        )
+
+        # Select appropriate project name based on whether the wheel was downloaded from pypi or not
+        if [[ "${{ inputs.update-wheel }}" == "true" || -n "${{ inputs.run_id }}" ]]; then
+          project_name="${raw_wheel_project_names[${{ matrix.build.project }}]}"
+        else
+          project_name="${pypi_wheel_project_names[${{ matrix.build.project }}]}"
+        fi
 
         echo "Set version to commit sha if called from other repo"
         if [[ "${{ inputs.update-wheel }}" == "true" || -n "${{ inputs.run_id }}" ]]; then
@@ -240,7 +242,7 @@ jobs:
 
         mlir_sha=""
         if [[ "${{ matrix.build.project }}" == "tt-torch" ]]; then
-          wget "https://raw.githubusercontent.com/tenstorrent/${{ matrix.build.project }}/${version}/third_party/CMakeLists.txt"
+          wget "https://raw.githubusercontent.com/tenstorrent/tt-torch/${version}/third_party/CMakeLists.txt"
           xla_sha=$(grep -E "set\(TT_XLA_VERSION" CMakeLists.txt | grep -oP '"\K[^"]+' | head -n 1)
           echo "XLA commit sha: $xla_sha"
           rm -f CMakeLists.txt


### PR DESCRIPTION
#### Problem
1. Python wheels for frontend have had their names changes which broke our custom ttrt download flow.
2. Tt-mlir artifacts have reached ~2.5gb unpacked which broke the download artifact action we use (it is a nodejs implementation under the hood and 2.5gb is bigger than it's buffer).

#### Solution 
1. Made changes to accomodate new naming conventions for wheels.
2. We just download the artifact with the action and then unzip them ourselves.