### PR TITLE
Use python 3.11 for all frontend wheels in tt-forge-slim 

### DIFF
--- a/.github/Dockerfile.tt-forge-slim
+++ b/.github/Dockerfile.tt-forge-slim
@@ -18,13 +18,7 @@ RUN apt-get update && \
     ca-certificates \
     sudo \
     ssh \
-    python3.10 \
-    python3.10-venv \
-    python3.10-dev \
-    python3-pip && \
-    # Make Python 3.10 the default
-    update-alternatives --install /usr/bin/python python /usr/bin/python3.10 1 && \
-    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1
+    python3-pip
 
 # Install system dependencies
 RUN apt-get update && \
@@ -39,7 +33,9 @@ RUN apt-get update && \
 # Install Python 3.11
 RUN add-apt-repository ppa:deadsnakes/ppa && \
     apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python3.11 python3.11-dev python3.11-venv python3.11-distutils
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python3.11 python3.11-dev python3.11-venv python3.11-distutils && \
+    update-alternatives --install /usr/bin/python python /usr/bin/python3.11 1 && \
+    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
 
 # Create forge user and home directory
 RUN useradd -m -s /bin/bash forge && \
@@ -61,13 +57,13 @@ RUN FRONTEND=tt-forge-fe && \
 
 # Create and activate virtual environment for tt-torch, install whl
 RUN FRONTEND=tt-torch && \
-    /usr/bin/python3.11 -m venv venv-$FRONTEND && \
+    python -m venv venv-$FRONTEND && \
     source venv-$FRONTEND/bin/activate && \
     pip install tt-torch --no-cache-dir --pre --extra-index-url https://pypi.eng.aws.tenstorrent.com/
 
 # Create and activate virtual environment for tt-xla, install whl
 RUN FRONTEND=tt-xla && \
-    /usr/bin/python3.11 -m venv venv-$FRONTEND && \
+    python -m venv venv-$FRONTEND && \
     source venv-$FRONTEND/bin/activate && \
     pip install pjrt-plugin-tt --no-cache-dir --pre --extra-index-url https://pypi.eng.aws.tenstorrent.com/
 


### PR DESCRIPTION
#### Problem
tt-forge-fe has bumped the python version to 3.11, we were installing the wheel with python 3.10.

#### Solution
Use python 3.11 for the installation of tt-forge-fe wheel.
All 3 frontend wheels are now using python 3.11, so 3.10 has been removed.

Nigthly workflow that validates the changes: [link](https://github.com/tenstorrent/tt-forge/actions/runs/17820974110).