### PR TITLE
update relative link to point to the right folder

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -23,7 +23,7 @@ This directory contains benchmark implementations of popular deep learning model
 
 ## Running Benchmarks
 
-Instructions for running performance benchmarks can be found [here](../../docs/src/getting_started.md).
+Instructions for running performance benchmarks can be found [here](../docs/src/getting_started.md#running-performance-benchmark-tests).
 
 ## Additional Resources
 


### PR DESCRIPTION
A page was moved from another repo that used a relative link to point at information. The link did not work in the new location. 

This pull request is to update the link in the README.md file to point to the benchmarking section of the getting_started.md page for TT-Forge. 