### PR TITLE
Download artifact action switch to using gh

### DIFF
--- a/.github/actions/download-artifact/action.yaml
+++ b/.github/actions/download-artifact/action.yaml
@@ -78,15 +78,6 @@ runs:
             return 1
           fi
 
-          ls -lah $path
-
-          # unzip -o "$path/${ARTIFACT_NAME}.zip" -d "$path"
-          # if [ $? -ne 0 ]; then
-          #   echo "Error: Failed to unzip artifact."
-          #   return 1
-          # fi
-          # rm "$path/${ARTIFACT_NAME}.zip"
-
           # Check if we need to untar
           for file in "$path"/*.tar*; do
             if [ -f "$file" ]; then


### PR DESCRIPTION
### Problem
/

### Improvement
Switch to using `gh` (github's cli tool) instead of downloading and unzipping files manually.
`gh run download` does a direct download and unzip of the artifact, this approach is simpler and will potentially give us performance benefits.

### Tests
The `Download Artifact Test` workflow is passing.