### PR TITLE
Enable sharding for all FFE benchmarks

### DIFF
--- a/benchmark/tt-forge-fe/efficientnet_timm.py
+++ b/benchmark/tt-forge-fe/efficientnet_timm.py
@@ -111,7 +111,7 @@ def test_efficientnet_timm(
 
     # Compiler configuration
     OPTIMIZER_ENABLED = True
-    MEMORY_LAYOUT_ANALYSIS_ENABLED = False
+    MEMORY_LAYOUT_ANALYSIS_ENABLED = True
     TRACE_ENABLED = False
     compiler_config = CompilerConfig()
     # Turn on MLIR optimizations.

--- a/benchmark/tt-forge-fe/llama_prefill.py
+++ b/benchmark/tt-forge-fe/llama_prefill.py
@@ -93,8 +93,8 @@ def test_llama_prefill(
     input_ids = tokenizer(prompt, return_tensors="pt").input_ids
 
     # Compiler configuration
-    OPTIMIZER_ENABLED = False
-    MEMORY_LAYOUT_ANALYSIS_ENABLED = False
+    OPTIMIZER_ENABLED = True
+    MEMORY_LAYOUT_ANALYSIS_ENABLED = True
     TRACE_ENABLED = False
     # @TODO - For now, we are skipping enabling MLIR optimizations, because it is not working with the current version of the model.
     # Turn on MLIR optimizations.

--- a/benchmark/tt-forge-fe/mnist_linear.py
+++ b/benchmark/tt-forge-fe/mnist_linear.py
@@ -43,9 +43,7 @@ MNIST_INPUT_FEATURE_SIZE = 784  # 784 = 28 * 28, default size of MNIST image
 MNIST_OUTPUT_FEATURE_SIZE = 10  # 10 classes in MNIST, default output size
 MNIIST_HIDDEN_SIZE = 256  # Hidden layer size, default size
 
-BATCH_SIZE = [
-    2**i for i in range(MNIST_BATCH_SIZE_EXP_RANGE)
-]  # Batch size, sizes will be 1, 2, 4, 8, 16, 32, 64, etc.
+BATCH_SIZE = [2**i for i in range(MNIST_BATCH_SIZE_EXP_RANGE)]  # Batch size, sizes will be 1, 2, 4, 8, 16, 32, 64, etc.
 INPUT_SIZE = [  # Input size, sizes will be 1 * 2^5 = 32, 3 * 2^5 = 96, 5 * 2^5 = 160, 7 * 2^5 = 224, etc.
     factor * hidden
     for factor in MNIIST_INPUT_SIZE_FACTORS
@@ -122,7 +120,7 @@ def test_mnist_linear(
         cpu_fps = -1.0
 
     OPTIMIZER_ENABLED = True
-    MEMORY_LAYOUT_ANALYSIS_ENABLED = False  # mnist_linear.py doesn't use set_enable_memory_layout_analysis
+    MEMORY_LAYOUT_ANALYSIS_ENABLED = True
     TRACE_ENABLED = False
     compiler_cfg = CompilerConfig()
     compiler_cfg.mlir_config = MLIRConfig().set_enable_optimizer(OPTIMIZER_ENABLED)

--- a/benchmark/tt-forge-fe/mnist_linear.py
+++ b/benchmark/tt-forge-fe/mnist_linear.py
@@ -43,7 +43,9 @@ MNIST_INPUT_FEATURE_SIZE = 784  # 784 = 28 * 28, default size of MNIST image
 MNIST_OUTPUT_FEATURE_SIZE = 10  # 10 classes in MNIST, default output size
 MNIIST_HIDDEN_SIZE = 256  # Hidden layer size, default size
 
-BATCH_SIZE = [2**i for i in range(MNIST_BATCH_SIZE_EXP_RANGE)]  # Batch size, sizes will be 1, 2, 4, 8, 16, 32, 64, etc.
+BATCH_SIZE = [
+    2**i for i in range(MNIST_BATCH_SIZE_EXP_RANGE)
+]  # Batch size, sizes will be 1, 2, 4, 8, 16, 32, 64, etc.
 INPUT_SIZE = [  # Input size, sizes will be 1 * 2^5 = 32, 3 * 2^5 = 96, 5 * 2^5 = 160, 7 * 2^5 = 224, etc.
     factor * hidden
     for factor in MNIIST_INPUT_SIZE_FACTORS

--- a/benchmark/tt-forge-fe/mobilenetv2_basic.py
+++ b/benchmark/tt-forge-fe/mobilenetv2_basic.py
@@ -108,7 +108,7 @@ def test_mobilenetv2_basic(
 
     # Compiler configuration
     OPTIMIZER_ENABLED = True
-    MEMORY_LAYOUT_ANALYSIS_ENABLED = False
+    MEMORY_LAYOUT_ANALYSIS_ENABLED = True
     TRACE_ENABLED = False
     compiler_config = CompilerConfig()
     # Turn on MLIR optimizations.

--- a/benchmark/tt-forge-fe/segformer.py
+++ b/benchmark/tt-forge-fe/segformer.py
@@ -118,7 +118,7 @@ def test_segformer(
 
     # Compiler configuration
     OPTIMIZER_ENABLED = True
-    MEMORY_LAYOUT_ANALYSIS_ENABLED = False
+    MEMORY_LAYOUT_ANALYSIS_ENABLED = True
     TRACE_ENABLED = False
     compiler_config = CompilerConfig()
     # Turn on MLIR optimizations.

--- a/benchmark/tt-forge-fe/unet.py
+++ b/benchmark/tt-forge-fe/unet.py
@@ -83,7 +83,7 @@ def test_unet(
         raise ValueError(f"Unsupported UNet variant: {variant}")
 
     OPTIMIZER_ENABLED = True
-    MEMORY_LAYOUT_ANALYSIS_ENABLED = False
+    MEMORY_LAYOUT_ANALYSIS_ENABLED = True
     TRACE_ENABLED = False
     compiler_config = CompilerConfig()
     compiler_config.enable_optimization_passes = True

--- a/benchmark/tt-forge-fe/vit.py
+++ b/benchmark/tt-forge-fe/vit.py
@@ -114,8 +114,8 @@ def test_vit_base(
         cpu_fps = -1.0
 
     # Compiler configuration
-    OPTIMIZER_ENABLED = False
-    MEMORY_LAYOUT_ANALYSIS_ENABLED = False  # vit.py doesn't use set_enable_memory_layout_analysis
+    OPTIMIZER_ENABLED = True
+    MEMORY_LAYOUT_ANALYSIS_ENABLED = True
     TRACE_ENABLED = False
     compiler_config = CompilerConfig()
     # @TODO - For now, we are skipping enabling MLIR optimizations, because it is not working with the current version of the model.

--- a/benchmark/tt-forge-fe/vovnet.py
+++ b/benchmark/tt-forge-fe/vovnet.py
@@ -126,7 +126,7 @@ def test_vovnet_timm(
 
     # Compiler configuration
     OPTIMIZER_ENABLED = True
-    MEMORY_LAYOUT_ANALYSIS_ENABLED = False
+    MEMORY_LAYOUT_ANALYSIS_ENABLED = True
     TRACE_ENABLED = False
     compiler_config = CompilerConfig()
     if data_format == "bfloat16":

--- a/benchmark/tt-forge-fe/yolo_v10.py
+++ b/benchmark/tt-forge-fe/yolo_v10.py
@@ -102,7 +102,7 @@ def test_yolo_v10(
 
     # Compiler configuration
     OPTIMIZER_ENABLED = True
-    MEMORY_LAYOUT_ANALYSIS_ENABLED = False
+    MEMORY_LAYOUT_ANALYSIS_ENABLED = True
     TRACE_ENABLED = False
     compiler_config = CompilerConfig()
 

--- a/benchmark/tt-forge-fe/yolo_v4.py
+++ b/benchmark/tt-forge-fe/yolo_v4.py
@@ -104,7 +104,7 @@ def test_yolo_v4(
 
     # Compiler configuration
     OPTIMIZER_ENABLED = True
-    MEMORY_LAYOUT_ANALYSIS_ENABLED = False
+    MEMORY_LAYOUT_ANALYSIS_ENABLED = True
     TRACE_ENABLED = False
     compiler_config = CompilerConfig()
     # Turn on MLIR optimizations.

--- a/benchmark/tt-forge-fe/yolo_v8.py
+++ b/benchmark/tt-forge-fe/yolo_v8.py
@@ -102,7 +102,7 @@ def test_yolo_v8(
 
     # Compiler configuration
     OPTIMIZER_ENABLED = True
-    MEMORY_LAYOUT_ANALYSIS_ENABLED = False
+    MEMORY_LAYOUT_ANALYSIS_ENABLED = True
     TRACE_ENABLED = False
     compiler_config = CompilerConfig()
     # Turn on MLIR optimizations.

--- a/benchmark/tt-forge-fe/yolo_v9.py
+++ b/benchmark/tt-forge-fe/yolo_v9.py
@@ -103,7 +103,7 @@ def test_yolo_v9(
 
     # Compiler configuration
     OPTIMIZER_ENABLED = True
-    MEMORY_LAYOUT_ANALYSIS_ENABLED = False
+    MEMORY_LAYOUT_ANALYSIS_ENABLED = True
     TRACE_ENABLED = False
     compiler_config = CompilerConfig()
     # Turn on MLIR optimizations.


### PR DESCRIPTION
Enable optimizer and memory layout analysis for all FFE benchmarks. This creates some perf improvements:

  | Model                | Main Results | Sharding Results | Improvement |
  |----------------------|--------------|------------------|-------------|
  | EfficientNet Timm B0 | 69.55        | 72.91            | +4.8%       |
  | MobileNet V2 Basic   | 229.36       | 256.21           | +11.7%      |
  | Resnet 50 HF         | 688.13       | 686.73           | -0.2%       |
  | Segformer            | 25.65        | 28.06            | +9.4%       |
  | ViT Base             | 68.38        | 68.53            | +0.2%       |
  | Vovnet Timm          | 240.50       | 256.75           | +6.8%       |
  | YOLOv10              | 10.60        | 13.27            | +25.2%      |
  | YOLOv4               | 9.89         | 10.45            | +5.7%       |
  | YOLOv8               | 14.43        | 18.30            | +26.8%      |
  | YOLOv9               | 15.61        | 15.56            | -0.3%       |
