### PR TITLE
Enable optimizer on xla benchmarks

### DIFF
--- a/benchmark/tt-xla/efficientnet.py
+++ b/benchmark/tt-xla/efficientnet.py
@@ -10,6 +10,7 @@ import pytest
 # Third-party modules
 import torch
 import torch.nn as nn
+import torch_xla
 import torch_xla.core.xla_model as xm
 import tt_torch
 from tqdm import tqdm
@@ -77,7 +78,7 @@ def test_efficientnet_torch_xla(
     if training:
         pytest.skip("Training is not supported")
 
-    OPTIMIZER_ENABLED = False
+    OPTIMIZER_ENABLED = True
     PROGRAM_CACHE_ENABLED = False
     MEMORY_LAYOUT_ANALYSIS_ENABLED = False
     TRACE_ENABLED = False
@@ -120,6 +121,14 @@ def test_efficientnet_torch_xla(
     else:
         cpu_fps = -1.0
 
+    options = {
+        "enable_optimizer": OPTIMIZER_ENABLED,
+        "enable_sharding": MEMORY_LAYOUT_ANALYSIS_ENABLED,
+        "enable_l1_interleaved": False,
+        "enable_fusing_conv2d_with_multiply_pattern": True,
+    }
+
+    torch_xla.set_custom_compile_options(options)
     # torch_xla compilation
     framework_model.compile(backend="tt")
 

--- a/benchmark/tt-xla/efficientnet.py
+++ b/benchmark/tt-xla/efficientnet.py
@@ -11,6 +11,7 @@ import pytest
 import torch
 import torch.nn as nn
 import torch_xla.core.xla_model as xm
+import tt_torch
 from tqdm import tqdm
 
 from benchmark.utils import load_benchmark_dataset, evaluate_classification, measure_cpu_fps
@@ -120,7 +121,7 @@ def test_efficientnet_torch_xla(
         cpu_fps = -1.0
 
     # torch_xla compilation
-    framework_model.compile(backend="openxla")
+    framework_model.compile(backend="tt")
 
     # Connect the device
     device = xm.xla_device()

--- a/benchmark/tt-xla/efficientnet.py
+++ b/benchmark/tt-xla/efficientnet.py
@@ -7,7 +7,7 @@ import os
 import time
 import pytest
 
-os.environ['TT_RUNTIME_ENABLE_PROGRAM_CACHE'] = '1'
+os.environ["TT_RUNTIME_ENABLE_PROGRAM_CACHE"] = "1"
 
 # Third-party modules
 import torch

--- a/benchmark/tt-xla/efficientnet.py
+++ b/benchmark/tt-xla/efficientnet.py
@@ -7,6 +7,8 @@ import os
 import time
 import pytest
 
+os.environ['TT_RUNTIME_ENABLE_PROGRAM_CACHE'] = '1'
+
 # Third-party modules
 import torch
 import torch.nn as nn

--- a/benchmark/tt-xla/mobilenetv2.py
+++ b/benchmark/tt-xla/mobilenetv2.py
@@ -10,6 +10,7 @@ import pytest
 # Third-party modules
 import torch
 import torch.nn as nn
+import torch_xla
 import torch_xla.core.xla_model as xm
 import tt_torch
 from tqdm import tqdm
@@ -77,7 +78,7 @@ def test_mobilenetv2_torch_xla(
     if training:
         pytest.skip("Training is not supported")
 
-    OPTIMIZER_ENABLED = False
+    OPTIMIZER_ENABLED = True
     PROGRAM_CACHE_ENABLED = False
     MEMORY_LAYOUT_ANALYSIS_ENABLED = False
     TRACE_ENABLED = False
@@ -119,6 +120,15 @@ def test_mobilenetv2_torch_xla(
         cpu_fps = measure_cpu_fps(framework_model, cpu_input)
     else:
         cpu_fps = -1.0
+
+    options = {
+        "enable_optimizer": OPTIMIZER_ENABLED,
+        "enable_sharding": MEMORY_LAYOUT_ANALYSIS_ENABLED,
+        "enable_l1_interleaved": False,
+        "enable_fusing_conv2d_with_multiply_pattern": True,
+    }
+
+    torch_xla.set_custom_compile_options(options)
 
     # torch_xla compilation
     framework_model.compile(backend="tt")

--- a/benchmark/tt-xla/mobilenetv2.py
+++ b/benchmark/tt-xla/mobilenetv2.py
@@ -7,7 +7,7 @@ import os
 import time
 import pytest
 
-os.environ['TT_RUNTIME_ENABLE_PROGRAM_CACHE'] = '1'
+os.environ["TT_RUNTIME_ENABLE_PROGRAM_CACHE"] = "1"
 
 # Third-party modules
 import torch

--- a/benchmark/tt-xla/mobilenetv2.py
+++ b/benchmark/tt-xla/mobilenetv2.py
@@ -7,6 +7,8 @@ import os
 import time
 import pytest
 
+os.environ['TT_RUNTIME_ENABLE_PROGRAM_CACHE'] = '1'
+
 # Third-party modules
 import torch
 import torch.nn as nn

--- a/benchmark/tt-xla/mobilenetv2.py
+++ b/benchmark/tt-xla/mobilenetv2.py
@@ -11,6 +11,7 @@ import pytest
 import torch
 import torch.nn as nn
 import torch_xla.core.xla_model as xm
+import tt_torch
 from tqdm import tqdm
 
 from benchmark.utils import load_benchmark_dataset, evaluate_classification, measure_cpu_fps
@@ -120,7 +121,7 @@ def test_mobilenetv2_torch_xla(
         cpu_fps = -1.0
 
     # torch_xla compilation
-    framework_model.compile(backend="openxla")
+    framework_model.compile(backend="tt")
 
     # Connect the device
     device = xm.xla_device()

--- a/benchmark/tt-xla/resnet.py
+++ b/benchmark/tt-xla/resnet.py
@@ -10,7 +10,9 @@ import pytest
 # Third-party modules
 import torch
 import torch.nn as nn
+import torch_xla
 import torch_xla.core.xla_model as xm
+import tt_torch
 from tqdm import tqdm
 
 from benchmark.utils import load_benchmark_dataset, evaluate_classification, measure_cpu_fps
@@ -122,8 +124,13 @@ def test_resnet_torch_xla(
     else:
         cpu_fps = -1.0
 
+    torch_xla.set_custom_compile_options({
+        "enable_optimizer": True,
+        "enable_memory_layout_analysis": True,
+    })
+    
     # torch_xla compilation
-    framework_model.compile(backend="openxla")
+    framework_model.compile(backend="tt")
 
     # Connect the device
     device = xm.xla_device()

--- a/benchmark/tt-xla/resnet.py
+++ b/benchmark/tt-xla/resnet.py
@@ -81,7 +81,7 @@ def test_resnet_torch_xla(
     if training:
         pytest.skip("Training is not supported")
 
-    OPTIMIZER_ENABLED = False
+    OPTIMIZER_ENABLED = True
     PROGRAM_CACHE_ENABLED = False
     MEMORY_LAYOUT_ANALYSIS_ENABLED = False
     TRACE_ENABLED = False
@@ -124,10 +124,14 @@ def test_resnet_torch_xla(
     else:
         cpu_fps = -1.0
 
-    torch_xla.set_custom_compile_options({
-        "enable_optimizer": True,
-        "enable_memory_layout_analysis": True,
-    })
+    options = {
+        "enable_optimizer": OPTIMIZER_ENABLED,
+        "enable_sharding": MEMORY_LAYOUT_ANALYSIS_ENABLED,
+        "enable_l1_interleaved": False,
+        "enable_fusing_conv2d_with_multiply_pattern": True,
+    }
+
+    torch_xla.set_custom_compile_options(options)
     
     # torch_xla compilation
     framework_model.compile(backend="tt")

--- a/benchmark/tt-xla/resnet.py
+++ b/benchmark/tt-xla/resnet.py
@@ -7,6 +7,8 @@ import os
 import time
 import pytest
 
+os.environ['TT_RUNTIME_ENABLE_PROGRAM_CACHE'] = '1'
+
 # Third-party modules
 import torch
 import torch.nn as nn

--- a/benchmark/tt-xla/resnet.py
+++ b/benchmark/tt-xla/resnet.py
@@ -7,7 +7,7 @@ import os
 import time
 import pytest
 
-os.environ['TT_RUNTIME_ENABLE_PROGRAM_CACHE'] = '1'
+os.environ["TT_RUNTIME_ENABLE_PROGRAM_CACHE"] = "1"
 
 # Third-party modules
 import torch
@@ -134,7 +134,7 @@ def test_resnet_torch_xla(
     }
 
     torch_xla.set_custom_compile_options(options)
-    
+
     # torch_xla compilation
     framework_model.compile(backend="tt")
 

--- a/benchmark/tt-xla/resnet_jax.py
+++ b/benchmark/tt-xla/resnet_jax.py
@@ -63,7 +63,7 @@ def test_resnet(
     if training:
         pytest.skip("Training is not supported")
 
-    OPTIMIZER_ENABLED = False
+    OPTIMIZER_ENABLED = True
     PROGRAM_CACHE_ENABLED = False
     MEMORY_LAYOUT_ANALYSIS_ENABLED = False
     TRACE_ENABLED = False

--- a/benchmark/tt-xla/segformer.py
+++ b/benchmark/tt-xla/segformer.py
@@ -11,6 +11,7 @@ import pytest
 import torch
 import torch.nn as nn
 import torch_xla.core.xla_model as xm
+import tt_torch
 from tqdm import tqdm
 
 from benchmark.utils import load_benchmark_dataset, evaluate_classification, measure_cpu_fps

--- a/benchmark/tt-xla/segformer.py
+++ b/benchmark/tt-xla/segformer.py
@@ -7,7 +7,7 @@ import os
 import time
 import pytest
 
-os.environ['TT_RUNTIME_ENABLE_PROGRAM_CACHE'] = '1'
+os.environ["TT_RUNTIME_ENABLE_PROGRAM_CACHE"] = "1"
 
 # Third-party modules
 import torch

--- a/benchmark/tt-xla/segformer.py
+++ b/benchmark/tt-xla/segformer.py
@@ -7,6 +7,8 @@ import os
 import time
 import pytest
 
+os.environ['TT_RUNTIME_ENABLE_PROGRAM_CACHE'] = '1'
+
 # Third-party modules
 import torch
 import torch.nn as nn

--- a/benchmark/tt-xla/segformer.py
+++ b/benchmark/tt-xla/segformer.py
@@ -10,6 +10,7 @@ import pytest
 # Third-party modules
 import torch
 import torch.nn as nn
+import torch_xla
 import torch_xla.core.xla_model as xm
 import tt_torch
 from tqdm import tqdm
@@ -77,7 +78,7 @@ def test_segformer_torch_xla(
     if training:
         pytest.skip("Training is not supported")
 
-    OPTIMIZER_ENABLED = False
+    OPTIMIZER_ENABLED = True
     PROGRAM_CACHE_ENABLED = False
     MEMORY_LAYOUT_ANALYSIS_ENABLED = False
     TRACE_ENABLED = False
@@ -119,6 +120,15 @@ def test_segformer_torch_xla(
         cpu_fps = measure_cpu_fps(framework_model, cpu_input)
     else:
         cpu_fps = -1.0
+
+    options = {
+        "enable_optimizer": OPTIMIZER_ENABLED,
+        "enable_sharding": MEMORY_LAYOUT_ANALYSIS_ENABLED,
+        "enable_l1_interleaved": False,
+        "enable_fusing_conv2d_with_multiply_pattern": True,
+    }
+
+    torch_xla.set_custom_compile_options(options)
 
     # torch_xla compilation
     framework_model.compile(backend="tt")

--- a/benchmark/tt-xla/unet.py
+++ b/benchmark/tt-xla/unet.py
@@ -10,6 +10,7 @@ import pytest
 # Third-party modules
 import torch
 import torch.nn as nn
+import torch_xla
 import torch_xla.core.xla_model as xm
 import tt_torch
 from tqdm import tqdm
@@ -73,7 +74,7 @@ def test_unet_torch_xla(
     if training:
         pytest.skip("Training is not supported")
 
-    OPTIMIZER_ENABLED = False
+    OPTIMIZER_ENABLED = True
     PROGRAM_CACHE_ENABLED = False
     MEMORY_LAYOUT_ANALYSIS_ENABLED = False
     TRACE_ENABLED = False
@@ -100,6 +101,15 @@ def test_unet_torch_xla(
         cpu_fps = measure_cpu_fps(framework_model, cpu_input)
     else:
         cpu_fps = -1.0
+
+    options = {
+        "enable_optimizer": OPTIMIZER_ENABLED,
+        "enable_sharding": MEMORY_LAYOUT_ANALYSIS_ENABLED,
+        "enable_l1_interleaved": False,
+        "enable_fusing_conv2d_with_multiply_pattern": True,
+    }
+
+    torch_xla.set_custom_compile_options(options)
 
     # torch_xla compilation
     framework_model.compile(backend="tt")

--- a/benchmark/tt-xla/unet.py
+++ b/benchmark/tt-xla/unet.py
@@ -7,7 +7,7 @@ import os
 import time
 import pytest
 
-os.environ['TT_RUNTIME_ENABLE_PROGRAM_CACHE'] = '1'
+os.environ["TT_RUNTIME_ENABLE_PROGRAM_CACHE"] = "1"
 
 # Third-party modules
 import torch

--- a/benchmark/tt-xla/unet.py
+++ b/benchmark/tt-xla/unet.py
@@ -7,6 +7,8 @@ import os
 import time
 import pytest
 
+os.environ['TT_RUNTIME_ENABLE_PROGRAM_CACHE'] = '1'
+
 # Third-party modules
 import torch
 import torch.nn as nn

--- a/benchmark/tt-xla/unet.py
+++ b/benchmark/tt-xla/unet.py
@@ -11,6 +11,7 @@ import pytest
 import torch
 import torch.nn as nn
 import torch_xla.core.xla_model as xm
+import tt_torch
 from tqdm import tqdm
 
 from benchmark.utils import measure_cpu_fps
@@ -101,7 +102,7 @@ def test_unet_torch_xla(
         cpu_fps = -1.0
 
     # torch_xla compilation
-    framework_model.compile(backend="openxla")
+    framework_model.compile(backend="tt")
 
     # Connect the device
     device = xm.xla_device()

--- a/benchmark/tt-xla/vit.py
+++ b/benchmark/tt-xla/vit.py
@@ -10,6 +10,7 @@ import pytest
 # Third-party modules
 import torch
 import torch.nn as nn
+import torch_xla
 import torch_xla.core.xla_model as xm
 import tt_torch
 from tqdm import tqdm
@@ -77,7 +78,7 @@ def test_vit_torch_xla(
     if training:
         pytest.skip("Training is not supported")
 
-    OPTIMIZER_ENABLED = False
+    OPTIMIZER_ENABLED = True
     PROGRAM_CACHE_ENABLED = False
     MEMORY_LAYOUT_ANALYSIS_ENABLED = False
     TRACE_ENABLED = False
@@ -119,6 +120,15 @@ def test_vit_torch_xla(
         cpu_fps = measure_cpu_fps(framework_model, cpu_input)
     else:
         cpu_fps = -1.0
+
+    options = {
+        "enable_optimizer": OPTIMIZER_ENABLED,
+        "enable_sharding": MEMORY_LAYOUT_ANALYSIS_ENABLED,
+        "enable_l1_interleaved": False,
+        "enable_fusing_conv2d_with_multiply_pattern": True,
+    }
+
+    torch_xla.set_custom_compile_options(options)
 
     # torch_xla compilation
     framework_model.compile(backend="tt")

--- a/benchmark/tt-xla/vit.py
+++ b/benchmark/tt-xla/vit.py
@@ -11,6 +11,7 @@ import pytest
 import torch
 import torch.nn as nn
 import torch_xla.core.xla_model as xm
+import tt_torch
 from tqdm import tqdm
 
 from benchmark.utils import load_benchmark_dataset, evaluate_classification, measure_cpu_fps

--- a/benchmark/tt-xla/vit.py
+++ b/benchmark/tt-xla/vit.py
@@ -7,7 +7,7 @@ import os
 import time
 import pytest
 
-os.environ['TT_RUNTIME_ENABLE_PROGRAM_CACHE'] = '1'
+os.environ["TT_RUNTIME_ENABLE_PROGRAM_CACHE"] = "1"
 
 # Third-party modules
 import torch

--- a/benchmark/tt-xla/vit.py
+++ b/benchmark/tt-xla/vit.py
@@ -7,6 +7,8 @@ import os
 import time
 import pytest
 
+os.environ['TT_RUNTIME_ENABLE_PROGRAM_CACHE'] = '1'
+
 # Third-party modules
 import torch
 import torch.nn as nn

--- a/benchmark/tt-xla/vovnet.py
+++ b/benchmark/tt-xla/vovnet.py
@@ -10,6 +10,7 @@ import pytest
 # Third-party modules
 import torch
 import torch.nn as nn
+import torch_xla
 import torch_xla.core.xla_model as xm
 import tt_torch
 from tqdm import tqdm
@@ -88,7 +89,7 @@ def test_vovnet_torch_xla(
     if training:
         pytest.skip("Training is not supported")
 
-    OPTIMIZER_ENABLED = False
+    OPTIMIZER_ENABLED = True
     PROGRAM_CACHE_ENABLED = False
     MEMORY_LAYOUT_ANALYSIS_ENABLED = False
     TRACE_ENABLED = False
@@ -128,6 +129,14 @@ def test_vovnet_torch_xla(
     else:
         cpu_fps = -1.0
 
+    options = {
+        "enable_optimizer": OPTIMIZER_ENABLED,
+        "enable_sharding": MEMORY_LAYOUT_ANALYSIS_ENABLED,
+        "enable_l1_interleaved": False,
+        "enable_fusing_conv2d_with_multiply_pattern": True,
+    }
+
+    torch_xla.set_custom_compile_options(options)
     # torch_xla compilation
     framework_model.compile(backend="tt")
 

--- a/benchmark/tt-xla/vovnet.py
+++ b/benchmark/tt-xla/vovnet.py
@@ -7,7 +7,7 @@ import os
 import time
 import pytest
 
-os.environ['TT_RUNTIME_ENABLE_PROGRAM_CACHE'] = '1'
+os.environ["TT_RUNTIME_ENABLE_PROGRAM_CACHE"] = "1"
 
 # Third-party modules
 import torch

--- a/benchmark/tt-xla/vovnet.py
+++ b/benchmark/tt-xla/vovnet.py
@@ -7,6 +7,8 @@ import os
 import time
 import pytest
 
+os.environ['TT_RUNTIME_ENABLE_PROGRAM_CACHE'] = '1'
+
 # Third-party modules
 import torch
 import torch.nn as nn

--- a/benchmark/tt-xla/vovnet.py
+++ b/benchmark/tt-xla/vovnet.py
@@ -11,6 +11,7 @@ import pytest
 import torch
 import torch.nn as nn
 import torch_xla.core.xla_model as xm
+import tt_torch
 from tqdm import tqdm
 
 from benchmark.utils import load_benchmark_dataset, evaluate_classification, measure_cpu_fps
@@ -128,7 +129,7 @@ def test_vovnet_torch_xla(
         cpu_fps = -1.0
 
     # torch_xla compilation
-    framework_model.compile(backend="openxla")
+    framework_model.compile(backend="tt")
 
     # Connect the device
     device = xm.xla_device()


### PR DESCRIPTION
This change is a WIP and is dependent on a few PR in other repos:
* https://github.com/tenstorrent/tt-xla/pull/1465
* https://github.com/tenstorrent/tt-mlir/pull/5102

The change includes the following for all xla benchmarks:
* Enable optimizer
* Enable multiply fusing
* Use custom tt_torch backend to enable const-eval