### PR TITLE
Fix ttrt install step

### DIFF
--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -235,7 +235,7 @@ jobs:
         if [[ "${{ inputs.update-wheel }}" == "true" || -n "${{ inputs.run_id }}" ]]; then
           version=$(pip freeze | grep -oP "$project_name-.+dev\.\K([^-]*)")
         else
-          version=$(pip freeze | grep "$project_name==" | grep -oP '==\K.*')
+          version=$(pip freeze | grep "$project_name==" | grep -oP '(\d+\.\d+\.\d+)(\.dev\d+|rc\d+)?')
         fi
 
         echo "Wheel version: $version"

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -235,7 +235,7 @@ jobs:
         if [[ "${{ inputs.update-wheel }}" == "true" || -n "${{ inputs.run_id }}" ]]; then
           version=$(pip freeze | grep -oP "$project_name-.+dev\.\K([^-]*)")
         else
-          version=$(pip freeze | grep "$project_name==" | grep -oP '(\d+\.\d+\.\d+)(\.dev\d+|rc\d+)?')
+          version=$(pip freeze | grep "$project_name" | grep -oP '(\d+\.\d+\.\d+)(\.dev\d+|rc\d+)?')
         fi
 
         echo "Wheel version: $version"


### PR DESCRIPTION
#### Problem
Regex for extracting frontend wheel's version fails when using wheels preinstalled in the tt-forge-slim docker.

#### Solution
Changed the regex which now works for: 
- dev versions(X.Y.Z.devYYYYMMDD)
- rc versions(X.Y.Z.rcN)
- stable versions(X.Y.Z.)

#### Test
Workflow that shows Performance Benchmark passing the ttrt install step with the new changes: [workflow](https://github.com/tenstorrent/tt-forge/actions/runs/18091850101).