### PR TITLE
bug: add post release testing

### DIFF
--- a/.github/actions/tt-forge-wheel/action.yml
+++ b/.github/actions/tt-forge-wheel/action.yml
@@ -34,10 +34,17 @@ runs:
       id: use-yesterday-version
       shell: bash
       run: |
-        NEW_VERSION_TAG=${{ inputs.new_version_tag }}
+        export NEW_VERSION_TAG=${{ inputs.new_version_tag }}
         if [[ "${{ inputs.draft }}" == "true" ]]; then
           # Take the last nightly release tag. Used for draft and workflow testing
           NEW_VERSION_TAG=$(gh release list -L 50 --repo ${{ inputs.repo_full }} --json tagName,isPrerelease,isDraft | jq -rc '[.[] | select(.isPrerelease==true and .isDraft==false) | select(.tagName | contains(".dev"))] | first | .tagName')
+          PJRT_PLUGIN_TT_TAG=${NEW_VERSION_TAG}
+          TT_FORGE_FE_TAG=${NEW_VERSION_TAG}
+
+        elif [[ "${{ inputs.release_type }}" == "nightly" ]]; then
+          # Wait on tt-forge-fe nightly release to be available on pypi
+          export PIP_WHEEL_NAMES="${{ steps.set-release-facts.outputs.pip_wheel_deps_names }}"
+          .github/scripts/wait-on-tt-pypi-wheels.sh
           PJRT_PLUGIN_TT_TAG=${NEW_VERSION_TAG}
           TT_FORGE_FE_TAG=${NEW_VERSION_TAG}
 

--- a/.github/scripts/wait-on-tt-pypi-wheels.sh
+++ b/.github/scripts/wait-on-tt-pypi-wheels.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# TEST:
+# NEW_VERSION_TAG="0.1.0.dev20250623"
+# PIP_WHEEL_NAMES="tt-torch tt_forge_fe tt_tvm pjrt-plugin-tt"
+
+set -eu
+attempts=30
+wait_time=10
+
+check_wheels() {
+  for wheel_name in $PIP_WHEEL_NAMES; do
+    # Check the only tenstorrent index for the wheel version
+    pip index versions $wheel_name --pre --index-url https://pypi.eng.aws.tenstorrent.com/ | grep $NEW_VERSION_TAG && echo "Found tag $NEW_VERSION_TAG for $wheel_name"
+  done
+}
+
+n=0
+
+until [ "$n" -ge $attempts ]; do
+  # Wait for pypi frontend wheels to be available
+  check_wheels && break
+  n=$((n+1))
+  echo "Waiting for pypi frontend wheels to be available on tt-pypi"
+  sleep $wait_time
+done

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -8,7 +8,7 @@ on:
         description: "Docker image used in tests"
         required: false
         type: string
-        default: "ghcr.io/tenstorrent/tt-forge/tt-forge-slim:latest"
+        default: "ghcr.io/tenstorrent/tt-forge-slim:latest"
       project-filter:
         description: "Project filter"
         required: false
@@ -41,6 +41,7 @@ on:
       docker-image:
         description: "Docker image used in tests"
         required: false
+        # TODO(vvasin): Update this to the new forge image after 0.4.0 is published for latest tag
         default: "ghcr.io/tenstorrent/forge-ubuntu-22-04-py3-11:latest"
         type: string
       project:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,18 +216,20 @@ jobs:
           wait_for_run_url: true
           json_params: '{"docker-image": "${{ needs.build-release.outputs.harbor_image_tag }}", "project-filter": "${{ steps.set-release-facts.outputs.repo_short }}", "test-filter": "${{ steps.set-release-facts.outputs.test_demo_filter }}" }'
 
-      - name: Trigger Docker Performance test ${{ steps.set-release-facts.outputs.repo_short }}
-        if: ${{  steps.set-release-facts.outputs.skip_docker_build == 'false' && steps.set-release-facts.outputs.test_perf == 'true' }}
-        uses: ./.github/actions/trigger-workflow
-        id: trigger-perf-test
-        env:
-          GH_TOKEN: ${{ github.token }}
-        with:
-          workflow_name: "Performance benchmark"
-          parent_run_id: "perf-test-${{ steps.set-release-facts.outputs.repo_short }}-${{ steps.set-release-facts.outputs.gh_new_version_tag }}-${{ needs.generate-seed.outputs.random-seed }}"
-          wait: ${{ steps.set-release-facts.outputs.test_demo_wait }}
-          wait_for_run_url: true
-          json_params: '{"docker-image": "${{ needs.build-release.outputs.image_tag }}", "project-filter": "${{ steps.set-release-facts.outputs.repo_short }}", "test-filter": "${{ steps.set-release-facts.outputs.test_perf_filter }}", "sh-runner": "${{ steps.set-release-facts.outputs.test_perf_sh_runner }}" }'
+# TODO: Re-enable this after adding tt-mlir version to frontend setup.py description
+# REF: https://github.com/tenstorrent/tt-forge/issues/170
+#      - name: Trigger Docker Performance test ${{ steps.set-release-facts.outputs.repo_short }}
+#        if: ${{  steps.set-release-facts.outputs.skip_docker_build == 'false' && steps.set-release-facts.outputs.test_perf == 'true' }}
+#        uses: ./.github/actions/trigger-workflow
+#        id: trigger-perf-test
+#        env:
+#          GH_TOKEN: ${{ github.token }}
+#        with:
+#          workflow_name: "Performance benchmark"
+#          parent_run_id: "perf-test-${{ steps.set-release-facts.outputs.repo_short }}-${{ steps.set-release-facts.outputs.gh_new_version_tag }}-${{ needs.generate-seed.outputs.random-seed }}"
+#          wait: ${{ steps.set-release-facts.outputs.test_demo_wait }}
+#          wait_for_run_url: true
+#          json_params: '{"docker-image": "${{ needs.build-release.outputs.image_tag }}", "project-filter": "${{ steps.set-release-facts.outputs.repo_short }}", "test-filter": "${{ steps.set-release-facts.outputs.test_perf_filter }}", "sh-runner": "${{ steps.set-release-facts.outputs.test_perf_sh_runner }}" }'
 
       - name: Wait for Basic tests
         if: ${{  steps.set-release-facts.outputs.skip_docker_build == 'false' }}
@@ -333,3 +335,41 @@ jobs:
           release-artifacts-id: ${{ needs.build-release.outputs.release-artifacts-id }}
           unique_artifact_suffix: ${{ needs.generate-seed.outputs.random-seed }}
           make_latest: ${{ inputs.make_latest || steps.set-release-facts.outputs.make_latest }}
+
+
+  # TODO: Shift this back up to test release after adding tt-mlir version to frontend setup.py description
+  # REF: https://github.com/tenstorrent/tt-forge/issues/170
+  test-release-after-publish:
+    name: "${{ inputs.draft && 'Draft' || '' }} Test after publish Release ${{ inputs.repo_short }} ${{ inputs.release_type }} ${{ inputs.new_version_tag}} ${{ inputs.branch }}"
+    if: ${{ inputs.draft || inputs.overwrite_releases || needs.build-release.outputs.check-tag == 'false'  }}
+    needs:
+      - build-release
+      - test-release
+      - publish-release
+      - generate-seed
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/set-release-facts
+        id: set-release-facts
+        with:
+          repo: ${{ inputs.repo }}
+          release_type: ${{ inputs.release_type }}
+          draft: ${{ inputs.draft }}
+          new_version_tag: ${{ inputs.new_version_tag }}
+
+      - name: Trigger Docker Performance test ${{ steps.set-release-facts.outputs.repo_short }}
+        if: ${{  steps.set-release-facts.outputs.skip_docker_build == 'false' && steps.set-release-facts.outputs.test_perf == 'true' }}
+        uses: ./.github/actions/trigger-workflow
+        id: trigger-perf-test
+        env:
+          GH_TOKEN: ${{ github.token }}
+        with:
+          workflow_name: "Performance benchmark"
+          parent_run_id: "perf-test-${{ steps.set-release-facts.outputs.repo_short }}-${{ steps.set-release-facts.outputs.gh_new_version_tag }}-${{ needs.generate-seed.outputs.random-seed }}"
+          wait: ${{ steps.set-release-facts.outputs.test_demo_wait }}
+          wait_for_run_url: true
+          json_params: '{"docker-image": "${{ needs.build-release.outputs.image_tag }}", "project-filter": "${{ steps.set-release-facts.outputs.repo_short }}", "test-filter": "${{ steps.set-release-facts.outputs.test_perf_filter }}", "sh-runner": "${{ steps.set-release-facts.outputs.test_perf_sh_runner }}" }'


### PR DESCRIPTION
Fixes issue where performance testing is trying to source a tt-mlir's frontend version before the frontend's tag is created. This didn't surface in testing as we use [yesterday's nightly version ](https://github.com/tenstorrent/tt-forge/blob/main/.github/actions/tt-forge-wheel/action.yml#L39) only for `tt-forge`

```bash
--2025-09-29 22:19:04--  https://raw.githubusercontent.com/tenstorrent/tt-torch/0.4.0/third_party/CMakeLists.txt
Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 185.199.110.133, 185.199.111.133, 185.199.108.133, ...
Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.110.133|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2025-09-29 22:19:04 ERROR 404: Not Found.
```
https://github.com/tenstorrent/tt-forge/actions/runs/18112257273/job/51540937006#step:10:53


The long-term fix will be implemented by adding the MLIR version to the setup.py of all frontends, as described in https://github.com/tenstorrent/tt-forge/issues/170 in our next release.
