### PR TITLE
Bug: fix blocking on tt-forge nightly wheel creation

### DIFF
--- a/.github/scripts/wait-on-tt-pypi-wheels.sh
+++ b/.github/scripts/wait-on-tt-pypi-wheels.sh
@@ -4,26 +4,22 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # TEST:
-# NEW_VERSION_TAG="0.1.0.dev20250623"
-# PIP_WHEEL_NAMES="tt-torch tt_forge_fe tt_tvm pjrt-plugin-tt"
+# export NEW_VERSION_TAG="0.1.0.dev20250623"
+# export PIP_WHEEL_NAMES="tt-torch tt_forge_fe tt_tvm pjrt-plugin-tt"
 
 set -eu
-attempts=30
-wait_time=10
+wait_time=60
 
 check_wheels() {
   for wheel_name in $PIP_WHEEL_NAMES; do
     # Check the only tenstorrent index for the wheel version
-    pip index versions $wheel_name --pre --index-url https://pypi.eng.aws.tenstorrent.com/ | grep $NEW_VERSION_TAG && echo "Found tag $NEW_VERSION_TAG for $wheel_name"
+    pip index versions $wheel_name --pre --index-url https://pypi.eng.aws.tenstorrent.com/ 2>/dev/null | grep -q $NEW_VERSION_TAG && echo "Found tag $NEW_VERSION_TAG for $wheel_name" || { echo "Can't find wheel $wheel_name for version $NEW_VERSION_TAG"; false; }
   done
 }
 
-n=0
-
-until [ "$n" -ge $attempts ]; do
+while true; do
   # Wait for pypi frontend wheels to be available
   check_wheels && break
-  n=$((n+1))
-  echo "Waiting for pypi frontend wheels to be available on tt-pypi"
+  echo "Waiting $wait_time seconds for pypi frontend wheels to be available on tt-pypi"
   sleep $wait_time
 done


### PR DESCRIPTION
Issue:
- `tt-forge` wheel needs all frontends in our tt-pypi available before wheel creation. The current script only blocks on this for a certain number of attempts.

Changes:
 - Remove attempt limit on tt pypi query for frontend wheels
 - Improved logging

Error logs:
```bash
0.662 Collecting tt-forge-fe@ https://pypi.eng.aws.tenstorrent.com/tt-forge-fe/tt_forge_fe-0.5.0.dev20251002-cp311-cp311-linux_x86_64.whl (from tt-forge==0.5.0.dev20251002)
0.883   ERROR: HTTP error 404 while getting https://pypi.eng.aws.tenstorrent.com/tt-forge-fe/tt_forge_fe-0.5.0.dev20251002-cp311-cp311-linux_x86_64.whl
0.931 ERROR: Could not install requirement tt-forge-fe@ https://pypi.eng.aws.tenstorrent.com/tt-forge-fe/tt_forge_fe-0.5.0.dev20251002-cp311-cp311-linux_x86_64.whl from https://pypi.eng.aws.tenstorrent.com/tt-forge-fe/tt_forge_fe-0.5.0.dev20251002-cp311-cp311-linux_x86_64.whl (from tt-forge==0.5.0.dev20251002) because of HTTP error 404 Client Error: Not Found for url: https://pypi.eng.aws.tenstorrent.com/tt-forge-fe/tt_forge_fe-0.5.0.dev20251002-cp311-cp311-linux_x86_64.whl for URL https://pypi.eng.aws.tenstorrent.com/tt-forge-fe/tt_forge_fe-0.5.0.dev20251002-cp311-cp311-linux_x86_64.whl
```
REF: https://github.com/tenstorrent/tt-forge/actions/runs/18182980687/job/51762285547#step:9:429