### PR TITLE
Calculate PCC for torch-xla models

### DIFF
--- a/benchmark/tt-xla/efficientnet.py
+++ b/benchmark/tt-xla/efficientnet.py
@@ -27,6 +27,7 @@ from .utils import (
     determine_model_type_and_dataset,
     print_benchmark_results,
     create_benchmark_result,
+    compute_pcc,
 )
 
 os.environ["PJRT_DEVICE"] = "TT"
@@ -96,13 +97,11 @@ def test_efficientnet_torch_xla(
         )
     elif task == "na":
         torch.manual_seed(1)
-        # Random data
         inputs = [torch.randn(batch_size, channel_size, *input_size)]
     else:
         raise ValueError(f"Unsupported task: {task}.")
 
     if data_format == "bfloat16":
-        # Convert input to bfloat16
         inputs = [item.to(torch.bfloat16) for item in inputs]
 
     # Load model using tt_forge_models
@@ -112,12 +111,10 @@ def test_efficientnet_torch_xla(
     framework_model: nn.Module = efficientnet_loader.load_model()
 
     if data_format == "bfloat16":
-        # Convert model to bfloat16
         framework_model = framework_model.to(torch.bfloat16)
     framework_model.eval()
 
     if measure_cpu:
-        # Use batch size 1
         cpu_input = inputs[0][0].reshape(1, *inputs[0][0].shape[0:])
         cpu_fps = measure_cpu_fps(framework_model, cpu_input)
     else:
@@ -125,33 +122,39 @@ def test_efficientnet_torch_xla(
 
     options = {
         "enable_optimizer": OPTIMIZER_ENABLED,
-        "enable_sharding": MEMORY_LAYOUT_ANALYSIS_ENABLED,
+        "enable_memory_layout_analysis": MEMORY_LAYOUT_ANALYSIS_ENABLED,
         "enable_l1_interleaved": False,
         "enable_fusing_conv2d_with_multiply_pattern": True,
     }
 
     torch_xla.set_custom_compile_options(options)
-    # torch_xla compilation
     framework_model.compile(backend="tt")
 
-    # Connect the device
     device = xm.xla_device()
 
-    # Move inputs and model to device
     if data_format == "bfloat16":
         framework_model = framework_model.to(device, dtype=torch.bfloat16)
     else:
         framework_model = framework_model.to(device)
 
-    # Move first input to device for verification
     device_input = inputs[0].to(device)
+
+    if task == "na":
+        cpu_model = EfficientNetLoader(model_variant).load_model()
+        if data_format == "bfloat16":
+            cpu_model = cpu_model.to(torch.bfloat16)
+        cpu_model.eval()
+        with torch.no_grad():
+            golden_output = cpu_model(inputs[0])
 
     with torch.no_grad():
         fw_out = framework_model(device_input)
 
     fw_out_cpu = fw_out.to("cpu")
-    print(f"Model verification - Output shape: {fw_out_cpu.shape}")
-    print(f"Model verification - Output (first 10 values): {fw_out_cpu.flatten()[:10]}")
+
+    if task == "na":
+        pcc_value = compute_pcc(golden_output, fw_out_cpu, required_pcc=0.97)
+        print(f"PCC verification passed with PCC={pcc_value:.6f}")
 
     if task == "classification":
         predictions = []
@@ -185,7 +188,6 @@ def test_efficientnet_torch_xla(
     model_type, dataset_name = determine_model_type_and_dataset(task, full_model_name)
     num_layers = 82
 
-    # Create custom measurements for CPU FPS
     custom_measurements = [
         {
             "measurement_name": "cpu_fps",

--- a/benchmark/tt-xla/resnet.py
+++ b/benchmark/tt-xla/resnet.py
@@ -24,6 +24,7 @@ from .utils import (
     determine_model_type_and_dataset,
     print_benchmark_results,
     create_benchmark_result,
+    compute_pcc,
 )
 
 os.environ["PJRT_DEVICE"] = "TT"
@@ -99,13 +100,11 @@ def test_resnet_torch_xla(
         )
     elif task == "na":
         torch.manual_seed(1)
-        # Random data
         inputs = [torch.randn(batch_size, channel_size, *input_size)]
     else:
         raise ValueError(f"Unsupported task: {task}.")
 
     if data_format == "bfloat16":
-        # Convert input to bfloat16
         inputs = [item.to(torch.bfloat16) for item in inputs]
 
     # Load model using tt_forge_models
@@ -115,12 +114,10 @@ def test_resnet_torch_xla(
     framework_model: nn.Module = resnet_loader.load_model()
 
     if data_format == "bfloat16":
-        # Convert model to bfloat16
         framework_model = framework_model.to(torch.bfloat16)
     framework_model.eval()
 
     if measure_cpu:
-        # Use batch size 1
         cpu_input = inputs[0][0].reshape(1, *inputs[0][0].shape[0:])
         cpu_fps = measure_cpu_fps(framework_model, cpu_input)
     else:
@@ -128,27 +125,33 @@ def test_resnet_torch_xla(
 
     options = {
         "enable_optimizer": OPTIMIZER_ENABLED,
-        "enable_sharding": MEMORY_LAYOUT_ANALYSIS_ENABLED,
+        "enable_memory_layout_analysis": MEMORY_LAYOUT_ANALYSIS_ENABLED,
         "enable_l1_interleaved": False,
         "enable_fusing_conv2d_with_multiply_pattern": True,
     }
 
     torch_xla.set_custom_compile_options(options)
 
-    # torch_xla compilation
     framework_model.compile(backend="tt")
 
-    # Connect the device
     device = xm.xla_device()
 
-    # Move inputs and model to device
     if data_format == "bfloat16":
         framework_model = framework_model.to(device, dtype=torch.bfloat16)
     else:
         framework_model = framework_model.to(device)
 
-    # Move first input to device for verification
     device_input = inputs[0].to(device)
+
+    if task == "na":
+        cpu_model = ResNetLoader(model_variant).load_model()
+        if data_format == "bfloat16":
+            cpu_model = cpu_model.to(torch.bfloat16)
+        cpu_model.eval()
+        with torch.no_grad():
+            golden_output = cpu_model(inputs[0])
+            if hasattr(golden_output, "logits"):
+                golden_output = golden_output.logits
 
     with torch.no_grad():
         fw_out = framework_model(device_input)
@@ -156,8 +159,10 @@ def test_resnet_torch_xla(
             fw_out = fw_out.logits
 
     fw_out_cpu = fw_out.to("cpu")
-    print(f"Model verification - Output shape: {fw_out_cpu.shape}")
-    print(f"Model verification - Output (first 10 values): {fw_out_cpu.flatten()[:10]}")
+
+    if task == "na":
+        pcc_value = compute_pcc(golden_output, fw_out_cpu, required_pcc=0.90)
+        print(f"PCC verification passed with PCC={pcc_value:.6f}")
 
     if task == "classification":
         predictions = []
@@ -193,7 +198,6 @@ def test_resnet_torch_xla(
     model_type, dataset_name = determine_model_type_and_dataset(task, full_model_name)
     num_layers = 50
 
-    # Create custom measurements for CPU FPS
     custom_measurements = [
         {
             "measurement_name": "cpu_fps",

--- a/benchmark/tt-xla/segformer.py
+++ b/benchmark/tt-xla/segformer.py
@@ -27,6 +27,7 @@ from .utils import (
     determine_model_type_and_dataset,
     print_benchmark_results,
     create_benchmark_result,
+    compute_pcc,
 )
 
 os.environ["PJRT_DEVICE"] = "TT"
@@ -96,13 +97,11 @@ def test_segformer_torch_xla(
         )
     elif task == "na":
         torch.manual_seed(1)
-        # Random data
         inputs = [torch.randn(batch_size, channel_size, *input_size)]
     else:
         raise ValueError(f"Unsupported task: {task}.")
 
     if data_format == "bfloat16":
-        # Convert input to bfloat16
         inputs = [item.to(torch.bfloat16) for item in inputs]
 
     # Load model using tt_forge_models
@@ -112,12 +111,10 @@ def test_segformer_torch_xla(
     framework_model: nn.Module = segformer_loader.load_model()
 
     if data_format == "bfloat16":
-        # Convert model to bfloat16
         framework_model = framework_model.to(torch.bfloat16)
     framework_model.eval()
 
     if measure_cpu:
-        # Use batch size 1
         cpu_input = inputs[0][0].reshape(1, *inputs[0][0].shape[0:])
         cpu_fps = measure_cpu_fps(framework_model, cpu_input)
     else:
@@ -125,27 +122,33 @@ def test_segformer_torch_xla(
 
     options = {
         "enable_optimizer": OPTIMIZER_ENABLED,
-        "enable_sharding": MEMORY_LAYOUT_ANALYSIS_ENABLED,
+        "enable_memory_layout_analysis": MEMORY_LAYOUT_ANALYSIS_ENABLED,
         "enable_l1_interleaved": False,
         "enable_fusing_conv2d_with_multiply_pattern": True,
     }
 
     torch_xla.set_custom_compile_options(options)
 
-    # torch_xla compilation
     framework_model.compile(backend="tt")
 
-    # Connect the device
     device = xm.xla_device()
 
-    # Move inputs and model to device
     if data_format == "bfloat16":
         framework_model = framework_model.to(device, dtype=torch.bfloat16)
     else:
         framework_model = framework_model.to(device)
 
-    # Move first input to device for verification
     device_input = inputs[0].to(device)
+
+    if task == "na":
+        cpu_model = segformer_loader.load_model()
+        if data_format == "bfloat16":
+            cpu_model = cpu_model.to(torch.bfloat16)
+        cpu_model.eval()
+        with torch.no_grad():
+            golden_output = cpu_model(inputs[0])
+            if hasattr(golden_output, "logits"):
+                golden_output = golden_output.logits
 
     with torch.no_grad():
         fw_out = framework_model(device_input)
@@ -153,8 +156,10 @@ def test_segformer_torch_xla(
             fw_out = fw_out.logits
 
     fw_out_cpu = fw_out.to("cpu")
-    print(f"Model verification - Output shape: {fw_out_cpu.shape}")
-    print(f"Model verification - Output (first 10 values): {fw_out_cpu.flatten()[:10]}")
+
+    if task == "na":
+        pcc_value = compute_pcc(golden_output, fw_out_cpu, required_pcc=0.97)
+        print(f"PCC verification passed with PCC={pcc_value:.6f}")
 
     if task == "classification":
         predictions = []
@@ -190,7 +195,6 @@ def test_segformer_torch_xla(
     model_type, dataset_name = determine_model_type_and_dataset(task, full_model_name)
     num_layers = 32
 
-    # Create custom measurements for CPU FPS
     custom_measurements = [
         {
             "measurement_name": "cpu_fps",

--- a/benchmark/tt-xla/utils.py
+++ b/benchmark/tt-xla/utils.py
@@ -5,6 +5,46 @@
 import socket
 from datetime import datetime
 from typing import Dict, Any, Optional, List
+import torch
+
+
+def compute_pcc(golden_output, device_output, required_pcc: float = 0.99) -> float:
+    """
+    Compute Pearson Correlation Coefficient between golden and device output.
+
+    Returns:
+        PCC value.
+
+    Raises:
+        AssertionError: If computed PCC is below required_pcc threshold
+    """
+    golden_flat = golden_output.to(torch.float32).flatten()
+    device_flat = device_output.to(torch.float32).flatten()
+
+    golden_centered = golden_flat - golden_flat.mean()
+    device_centered = device_flat - device_flat.mean()
+
+    denom = golden_centered.norm() * device_centered.norm()
+
+    # Handle edge case where tensors are too close (denom approaches 0)
+    if denom == 0:
+        # Check if tensors are actually equal using allclose
+        if torch.allclose(golden_flat, device_flat, rtol=1e-2, atol=1e-2):
+            print(f"PCC check: Tensors are nearly identical (allclose passed), PCC=1.0")
+            return 1.0
+        # If not close, this is an error case
+        raise AssertionError("PCC computation failed: denominator is zero but tensors are not close")
+
+    pcc = (golden_centered @ device_centered) / denom
+    pcc_value = pcc.item()
+
+    print(f"PCC check: Calculated PCC={pcc_value:.6f}, Required PCC={required_pcc}")
+
+    assert pcc_value >= required_pcc, (
+        f"PCC comparison failed. " f"Calculated: pcc={pcc_value:.6f}. Required: pcc={required_pcc}"
+    )
+
+    return pcc_value
 
 
 def get_benchmark_metadata() -> Dict[str, str]:

--- a/benchmark/tt-xla/vit.py
+++ b/benchmark/tt-xla/vit.py
@@ -27,6 +27,7 @@ from .utils import (
     determine_model_type_and_dataset,
     print_benchmark_results,
     create_benchmark_result,
+    compute_pcc,
 )
 
 os.environ["PJRT_DEVICE"] = "TT"
@@ -96,13 +97,11 @@ def test_vit_torch_xla(
         )
     elif task == "na":
         torch.manual_seed(1)
-        # Random data
         inputs = [torch.randn(batch_size, channel_size, *input_size)]
     else:
         raise ValueError(f"Unsupported task: {task}.")
 
     if data_format == "bfloat16":
-        # Convert input to bfloat16
         inputs = [item.to(torch.bfloat16) for item in inputs]
 
     # Load model using tt_forge_models
@@ -112,12 +111,10 @@ def test_vit_torch_xla(
     framework_model: nn.Module = vit_loader.load_model()
 
     if data_format == "bfloat16":
-        # Convert model to bfloat16
         framework_model = framework_model.to(torch.bfloat16)
     framework_model.eval()
 
     if measure_cpu:
-        # Use batch size 1
         cpu_input = inputs[0][0].reshape(1, *inputs[0][0].shape[0:])
         cpu_fps = measure_cpu_fps(framework_model, cpu_input)
     else:
@@ -125,27 +122,33 @@ def test_vit_torch_xla(
 
     options = {
         "enable_optimizer": OPTIMIZER_ENABLED,
-        "enable_sharding": MEMORY_LAYOUT_ANALYSIS_ENABLED,
+        "enable_memory_layout_analysis": MEMORY_LAYOUT_ANALYSIS_ENABLED,
         "enable_l1_interleaved": False,
         "enable_fusing_conv2d_with_multiply_pattern": True,
     }
 
     torch_xla.set_custom_compile_options(options)
 
-    # torch_xla compilation
     framework_model.compile(backend="tt")
 
-    # Connect the device
     device = xm.xla_device()
 
-    # Move inputs and model to device
     if data_format == "bfloat16":
         framework_model = framework_model.to(device, dtype=torch.bfloat16)
     else:
         framework_model = framework_model.to(device)
 
-    # Move first input to device for verification
     device_input = inputs[0].to(device)
+
+    if task == "na":
+        cpu_model = ViTLoader(model_variant).load_model()
+        if data_format == "bfloat16":
+            cpu_model = cpu_model.to(torch.bfloat16)
+        cpu_model.eval()
+        with torch.no_grad():
+            golden_output = cpu_model(inputs[0])
+            if hasattr(golden_output, "logits"):
+                golden_output = golden_output.logits
 
     with torch.no_grad():
         fw_out = framework_model(device_input)
@@ -153,8 +156,10 @@ def test_vit_torch_xla(
             fw_out = fw_out.logits
 
     fw_out_cpu = fw_out.to("cpu")
-    print(f"Model verification - Output shape: {fw_out_cpu.shape}")
-    print(f"Model verification - Output (first 10 values): {fw_out_cpu.flatten()[:10]}")
+
+    if task == "na":
+        pcc_value = compute_pcc(golden_output, fw_out_cpu, required_pcc=0.97)
+        print(f"PCC verification passed with PCC={pcc_value:.6f}")
 
     if task == "classification":
         predictions = []
@@ -190,7 +195,6 @@ def test_vit_torch_xla(
     model_type, dataset_name = determine_model_type_and_dataset(task, full_model_name)
     num_layers = 12
 
-    # Create custom measurements for CPU FPS
     custom_measurements = [
         {
             "measurement_name": "cpu_fps",

--- a/benchmark/tt-xla/vovnet.py
+++ b/benchmark/tt-xla/vovnet.py
@@ -24,6 +24,7 @@ from .utils import (
     determine_model_type_and_dataset,
     print_benchmark_results,
     create_benchmark_result,
+    compute_pcc,
 )
 
 os.environ["PJRT_DEVICE"] = "TT"
@@ -125,7 +126,6 @@ def test_vovnet_torch_xla(
     framework_model.eval()
 
     if measure_cpu:
-        # Use batch size 1
         cpu_input = inputs[0][0].reshape(1, *inputs[0][0].shape[0:])
         cpu_fps = measure_cpu_fps(framework_model, cpu_input)
     else:
@@ -133,33 +133,39 @@ def test_vovnet_torch_xla(
 
     options = {
         "enable_optimizer": OPTIMIZER_ENABLED,
-        "enable_sharding": MEMORY_LAYOUT_ANALYSIS_ENABLED,
+        "enable_memory_layout_analysis": MEMORY_LAYOUT_ANALYSIS_ENABLED,
         "enable_l1_interleaved": False,
         "enable_fusing_conv2d_with_multiply_pattern": True,
     }
 
     torch_xla.set_custom_compile_options(options)
-    # torch_xla compilation
     framework_model.compile(backend="tt")
 
-    # Connect the device
     device = xm.xla_device()
 
-    # Move inputs and model to device
     if data_format == "bfloat16":
         framework_model = framework_model.to(device, dtype=torch.bfloat16)
     else:
         framework_model = framework_model.to(device)
 
-    # Move first input to device for verification
     device_input = inputs[0].to(device)
+
+    if task == "na":
+        cpu_model = VovNetLoader(model_variant).load_model()
+        if data_format == "bfloat16":
+            cpu_model = cpu_model.to(torch.bfloat16)
+        cpu_model.eval()
+        with torch.no_grad():
+            golden_output = cpu_model(inputs[0])
 
     with torch.no_grad():
         fw_out = framework_model(device_input)
 
     fw_out_cpu = fw_out.to("cpu")
-    print(f"Model verification - Output shape: {fw_out_cpu.shape}")
-    print(f"Model verification - Output (first 10 values): {fw_out_cpu.flatten()[:10]}")
+
+    if task == "na":
+        pcc_value = compute_pcc(golden_output, fw_out_cpu, required_pcc=0.97)
+        print(f"PCC verification passed with PCC={pcc_value:.6f}")
 
     if task == "classification":
         predictions = []
@@ -193,7 +199,6 @@ def test_vovnet_torch_xla(
     model_type, dataset_name = determine_model_type_and_dataset(task, full_model_name)
     num_layers = -1
 
-    # Create custom measurements for CPU FPS
     custom_measurements = [
         {
             "measurement_name": "cpu_fps",

--- a/benchmark/tt-xla/yolov4.py
+++ b/benchmark/tt-xla/yolov4.py
@@ -24,6 +24,7 @@ from .utils import (
     determine_model_type_and_dataset,
     print_benchmark_results,
     create_benchmark_result,
+    compute_pcc,
 )
 
 os.environ["PJRT_DEVICE"] = "TT"
@@ -82,7 +83,6 @@ def test_yolov4_torch_xla(
     MEMORY_LAYOUT_ANALYSIS_ENABLED = False
     TRACE_ENABLED = False
 
-    # Create random inputs
     if task == "na":
         torch.manual_seed(1)
         inputs = [torch.randn(batch_size, channel_size, input_size[0], input_size[1])]
@@ -90,7 +90,6 @@ def test_yolov4_torch_xla(
         raise ValueError(f"Unsupported task: {task}.")
 
     if data_format == "bfloat16":
-        # Convert input to bfloat16
         inputs = [item.to(torch.bfloat16) for item in inputs]
 
     # Load YOLO model
@@ -98,13 +97,11 @@ def test_yolov4_torch_xla(
     framework_model = Yolov4Wrapper(framework_model)
 
     if data_format == "bfloat16":
-        # Convert model to bfloat16
         framework_model = framework_model.to(torch.bfloat16)
 
     framework_model.eval()
 
     if measure_cpu:
-        # Use batch size 1
         cpu_input = inputs[0][0].reshape(1, *inputs[0][0].shape[0:])
         cpu_fps = measure_cpu_fps(framework_model, cpu_input)
     else:
@@ -112,34 +109,41 @@ def test_yolov4_torch_xla(
 
     options = {
         "enable_optimizer": OPTIMIZER_ENABLED,
-        "enable_sharding": MEMORY_LAYOUT_ANALYSIS_ENABLED,
+        "enable_memory_layout_analysis": MEMORY_LAYOUT_ANALYSIS_ENABLED,
         "enable_l1_interleaved": False,
         "enable_fusing_conv2d_with_multiply_pattern": True,
     }
 
     torch_xla.set_custom_compile_options(options)
 
-    # torch_xla compilation
     framework_model.compile(backend="tt")
 
-    # Connect the device
     device = xm.xla_device()
 
-    # Move inputs and model to device
     if data_format == "bfloat16":
         framework_model = framework_model.to(device, dtype=torch.bfloat16)
     else:
         framework_model = framework_model.to(device)
 
-    # Move first input to device for verification
     device_input = inputs[0].to(device)
+
+    if task == "na":
+        cpu_model = ModelLoader.load_model()
+        cpu_model = Yolov4Wrapper(cpu_model)
+        if data_format == "bfloat16":
+            cpu_model = cpu_model.to(torch.bfloat16)
+        cpu_model.eval()
+        with torch.no_grad():
+            golden_output = cpu_model(inputs[0])
 
     with torch.no_grad():
         fw_out = framework_model(device_input)
 
     fw_out_cpu = [output.to("cpu") for output in fw_out]
-    print(f"Model verification - Output shapes: {[out.shape for out in fw_out_cpu]}")
-    print(f"Model verification - Output (first 10 values): {fw_out_cpu[0].flatten()[:10]}")
+
+    if task == "na":
+        pcc_value = compute_pcc(golden_output[0], fw_out_cpu[0], required_pcc=0.97)
+        print(f"PCC verification passed with PCC={pcc_value:.6f}")
 
     if task == "na":
         start = time.time()
@@ -161,7 +165,6 @@ def test_yolov4_torch_xla(
     model_type, dataset_name = determine_model_type_and_dataset(task, full_model_name)
     num_layers = -1
 
-    # Create custom measurements for CPU FPS
     custom_measurements = [
         {
             "measurement_name": "cpu_fps",

--- a/benchmark/tt-xla/yolov8.py
+++ b/benchmark/tt-xla/yolov8.py
@@ -23,6 +23,7 @@ from .utils import (
     determine_model_type_and_dataset,
     print_benchmark_results,
     create_benchmark_result,
+    compute_pcc,
 )
 
 os.environ["PJRT_DEVICE"] = "TT"
@@ -81,7 +82,6 @@ def test_yolov8_torch_xla(
     MEMORY_LAYOUT_ANALYSIS_ENABLED = False
     TRACE_ENABLED = False
 
-    # Create random inputs
     if task == "na":
         torch.manual_seed(1)
         inputs = [torch.randn(batch_size, channel_size, input_size[0], input_size[1])]
@@ -89,20 +89,16 @@ def test_yolov8_torch_xla(
         raise ValueError(f"Unsupported task: {task}.")
 
     if data_format == "bfloat16":
-        # Convert input to bfloat16
         inputs = [item.to(torch.bfloat16) for item in inputs]
 
-    # Load YOLO model weights, initialize and load model
     url = "https://github.com/ultralytics/assets/releases/download/v8.2.0/yolov8x.pt"
     framework_model = YoloWrapper(url)
 
     if data_format == "bfloat16":
-        # Convert model to bfloat16
         framework_model = framework_model.to(torch.bfloat16)
     framework_model.eval()
 
     if measure_cpu:
-        # Use batch size 1
         cpu_input = inputs[0][0].reshape(1, *inputs[0][0].shape[0:])
         cpu_fps = measure_cpu_fps(framework_model, cpu_input)
     else:
@@ -110,34 +106,41 @@ def test_yolov8_torch_xla(
 
     options = {
         "enable_optimizer": OPTIMIZER_ENABLED,
-        "enable_sharding": MEMORY_LAYOUT_ANALYSIS_ENABLED,
+        "enable_memory_layout_analysis": MEMORY_LAYOUT_ANALYSIS_ENABLED,
         "enable_l1_interleaved": False,
         "enable_fusing_conv2d_with_multiply_pattern": True,
     }
 
     torch_xla.set_custom_compile_options(options)
 
-    # torch_xla compilation
     framework_model.compile(backend="tt")
 
-    # Connect the device
     device = xm.xla_device()
 
-    # Move inputs and model to device
     if data_format == "bfloat16":
         framework_model = framework_model.to(device, dtype=torch.bfloat16)
     else:
         framework_model = framework_model.to(device)
 
-    # Move first input to device for verification
     device_input = inputs[0].to(device)
+
+    if task == "na":
+        url = "https://github.com/ultralytics/assets/releases/download/v8.2.0/yolov8x.pt"
+        cpu_model = YoloWrapper(url)
+        if data_format == "bfloat16":
+            cpu_model = cpu_model.to(torch.bfloat16)
+        cpu_model.eval()
+        with torch.no_grad():
+            golden_output = cpu_model(inputs[0])
 
     with torch.no_grad():
         fw_out = framework_model(device_input)
 
     fw_out_cpu = [output.to("cpu") for output in fw_out]
-    print(f"Model verification - Output shapes: {[out.shape for out in fw_out_cpu]}")
-    print(f"Model verification - Output (first 10 values): {fw_out_cpu[0].flatten()[:10]}")
+
+    if task == "na":
+        pcc_value = compute_pcc(golden_output[0], fw_out_cpu[0], required_pcc=0.97)
+        print(f"PCC verification passed with PCC={pcc_value:.6f}")
 
     if task == "na":
         start = time.time()
@@ -159,7 +162,6 @@ def test_yolov8_torch_xla(
     model_type, dataset_name = determine_model_type_and_dataset(task, full_model_name)
     num_layers = -1
 
-    # Create custom measurements for CPU FPS
     custom_measurements = [
         {
             "measurement_name": "cpu_fps",

--- a/benchmark/tt-xla/yolov9.py
+++ b/benchmark/tt-xla/yolov9.py
@@ -24,6 +24,7 @@ from .utils import (
     determine_model_type_and_dataset,
     print_benchmark_results,
     create_benchmark_result,
+    compute_pcc,
 )
 
 os.environ["PJRT_DEVICE"] = "TT"
@@ -82,7 +83,6 @@ def test_yolov9_torch_xla(
     MEMORY_LAYOUT_ANALYSIS_ENABLED = False
     TRACE_ENABLED = False
 
-    # Create random inputs
     if task == "na":
         torch.manual_seed(1)
         inputs = [torch.randn(batch_size, channel_size, input_size[0], input_size[1])]
@@ -90,7 +90,6 @@ def test_yolov9_torch_xla(
         raise ValueError(f"Unsupported task: {task}.")
 
     if data_format == "bfloat16":
-        # Convert input to bfloat16
         inputs = [item.to(torch.bfloat16) for item in inputs]
 
     # Load model using tt_forge_models
@@ -103,7 +102,6 @@ def test_yolov9_torch_xla(
     framework_model.eval()
 
     if measure_cpu:
-        # Use batch size 1
         cpu_input = inputs[0][0].reshape(1, *inputs[0][0].shape[0:])
         cpu_fps = measure_cpu_fps(framework_model, cpu_input)
     else:
@@ -111,31 +109,39 @@ def test_yolov9_torch_xla(
 
     options = {
         "enable_optimizer": OPTIMIZER_ENABLED,
-        "enable_sharding": MEMORY_LAYOUT_ANALYSIS_ENABLED,
+        "enable_memory_layout_analysis": MEMORY_LAYOUT_ANALYSIS_ENABLED,
         "enable_l1_interleaved": False,
         "enable_fusing_conv2d_with_multiply_pattern": True,
     }
 
     torch_xla.set_custom_compile_options(options)
 
-    # torch_xla compilation
     framework_model.compile(backend="tt")
 
-    # Connect the device
     device = xm.xla_device()
 
-    # Move inputs and model to device
     framework_model = framework_model.to(device)
 
-    # Move first input to device for verification
     device_input = inputs[0].to(device)
+
+    if task == "na":
+        yolov9_cpu_loader = YOLOv9Loader()
+        if data_format == "bfloat16":
+            cpu_model: nn.Module = yolov9_cpu_loader.load_model(dtype_override=torch.bfloat16)
+        else:
+            cpu_model: nn.Module = yolov9_cpu_loader.load_model()
+        cpu_model.eval()
+        with torch.no_grad():
+            golden_output = cpu_model(inputs[0])
 
     with torch.no_grad():
         fw_out = framework_model(device_input)
 
     fw_out_cpu = [output.to("cpu") for output in fw_out]
-    print(f"Model verification - Output shapes: {[out.shape for out in fw_out_cpu]}")
-    print(f"Model verification - Output (first 10 values): {fw_out_cpu[0].flatten()[:10]}")
+
+    if task == "na":
+        pcc_value = compute_pcc(golden_output[0], fw_out_cpu[0], required_pcc=0.97)
+        print(f"PCC verification passed with PCC={pcc_value:.6f}")
 
     if task == "na":
         start = time.time()
@@ -157,7 +163,6 @@ def test_yolov9_torch_xla(
     model_type, dataset_name = determine_model_type_and_dataset(task, full_model_name)
     num_layers = -1
 
-    # Create custom measurements for CPU FPS
     custom_measurements = [
         {
             "measurement_name": "cpu_fps",


### PR DESCRIPTION
Since torch-xla models currently run on random data, PCC check should be added until measuring accuracy on datasets is introduced.

- Added a function for calculating PCC in benchmark/tt-xla/utils.py
- Added PCC check for torch-xla models
- Updated `enable_sharding` compile config to `enable_memory_layout_analysis` 
- Removed some redundant comments