### PR TITLE
bug: fix perf & demo test reporting

### DIFF
--- a/.github/actions/set-release-facts/action.yaml
+++ b/.github/actions/set-release-facts/action.yaml
@@ -126,6 +126,9 @@ outputs:
   test_perf:
     description: "Test perf"
     value: ${{ steps.set-manifest.outputs.test_perf }}
+  basic_tests_runner_filter:
+    description: "Basic tests runner filter"
+    value: ${{ steps.set-manifest.outputs.basic_tests_runner_filter }}
 
 runs:
   using: "composite"
@@ -166,6 +169,7 @@ runs:
         test_perf_filter=""
         test_demo_wait="false"
         python_version="3.11"
+        basic_tests_runner_filter="All"
 
         # Tag & Release Defaults
 
@@ -245,6 +249,8 @@ runs:
             test_demo_filter="bge_m3"
             test_perf_filter="resnet"
             test_demo_wait="true"
+            # Only run basic tests on n150 for draft releases until Civ2 capacity improves
+            basic_tests_runner_filter="tt-ubuntu-2204-n150-stable"
             #test_perf_sh_runner="true"
 
             # null out the commit to so integration testing can pick up the arfiacts from the repo.
@@ -315,6 +321,7 @@ runs:
         echo "test_perf_filter=$test_perf_filter"
         echo "test_perf_sh_runner=$test_perf_sh_runner"
         echo "test_perf=$test_perf"
+        echo "basic_tests_runner_filter=$basic_tests_runner_filter"
 
         # Set outputs
         echo "workflow=$workflow" >> $GITHUB_OUTPUT
@@ -352,3 +359,4 @@ runs:
         echo "test_perf_filter=$test_perf_filter" >> $GITHUB_OUTPUT
         echo "test_perf_sh_runner=$test_perf_sh_runner" >> $GITHUB_OUTPUT
         echo "test_perf=$test_perf" >> $GITHUB_OUTPUT
+        echo "basic_tests_runner_filter=$basic_tests_runner_filter"

--- a/.github/actions/set-release-facts/action.yaml
+++ b/.github/actions/set-release-facts/action.yaml
@@ -359,4 +359,4 @@ runs:
         echo "test_perf_filter=$test_perf_filter" >> $GITHUB_OUTPUT
         echo "test_perf_sh_runner=$test_perf_sh_runner" >> $GITHUB_OUTPUT
         echo "test_perf=$test_perf" >> $GITHUB_OUTPUT
-        echo "basic_tests_runner_filter=$basic_tests_runner_filter"
+        echo "basic_tests_runner_filter=$basic_tests_runner_filter" >> $GITHUB_OUTPUT

--- a/.github/actions/wait-workflow/action.yml
+++ b/.github/actions/wait-workflow/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: "Wait only for run url"
     required: false
     default: false
+  watch_interval:
+    description: "Interval to watch for workflow run"
+    required: false
+    default: 60
 
 outputs:
   run_head_sha:
@@ -89,7 +93,7 @@ runs:
         if [[ "${{ inputs.wait_for_run_url }}" == "true" ]]; then
           echo "Workflow run url: $run_url"
         else
-          gh run watch $match_run_id
+          gh run watch --interval ${{ inputs.watch_interval }} $match_run_id
           echo "Workflow run completed"
           echo "Workflow run url: $run_url"
           run_conclusion=$(gh run view $match_run_id --json conclusion | jq -rc '.conclusion')

--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -24,6 +24,15 @@ on:
           - tt-xla
           - tt-forge
         default: tt-forge
+      runner-filter:
+        description: "Runner filter"
+        required: false
+        type: choice
+        options:
+          - tt-ubuntu-2204-n150-stable
+          - tt-ubuntu-2204-p150b-stable
+          - All
+        default: All
 
   workflow_call:
     inputs:
@@ -46,7 +55,11 @@ jobs:
 
           project_filter="${{ inputs.project-filter }}"
 
-          runs_on="tt-ubuntu-2204-n150-stable tt-ubuntu-2204-p150b-stable"
+          if [ "${{ inputs.runner-filter }}" == "All" ]; then
+            runs_on="tt-ubuntu-2204-n150-stable tt-ubuntu-2204-p150b-stable"
+          else
+            runs_on="${{ inputs.runner-filter }}"
+          fi
 
           if [ "${{ inputs.project-filter }}" == "tt-forge" ]; then
             frontends="tt-xla tt-forge-fe"

--- a/.github/workflows/demo-tests.yml
+++ b/.github/workflows/demo-tests.yml
@@ -225,6 +225,8 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
+      - name: checkout repository
+        uses: actions/checkout@v4
       - name: Trigger produce_data.yml
         uses: ./.github/actions/trigger-workflow
         env:

--- a/.github/workflows/demo-tests.yml
+++ b/.github/workflows/demo-tests.yml
@@ -41,6 +41,12 @@ on:
         required: false
         default: "All"
 
+
+# Used for produce_data.yml workflow dispatch trigger
+permissions:
+  id-token: write
+  actions: write
+
 jobs:
   set-matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/demo-tests.yml
+++ b/.github/workflows/demo-tests.yml
@@ -168,19 +168,11 @@ jobs:
           demo_file=$(basename "${{ matrix.path }}")
           python $demo_file
 
-  produce-data:
-    if: always()
-    needs: demo-test
-    uses: ./.github/workflows/produce_data.yml
-    with:
-      run_id: ${{ github.run_id }}
-      run_attempt: ${{ github.run_attempt }}
 
   fail-notify:
     if: always()
     needs:
       - demo-test
-      - produce-data
     runs-on: ubuntu-latest
     outputs:
       is-main: ${{ steps.branch-check.outputs.IS_MAIN }}
@@ -225,3 +217,20 @@ jobs:
             }
         env:
           SLACK_WEBHOOK_URL: ${{ inputs.slack-token || secrets.SLACK_NIGHTLY_FAIL }}
+
+
+  produce-data:
+    needs:
+      - fail-send-msg
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger produce_data.yml
+        uses: ./.github/actions/trigger-workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
+        with:
+          workflow_name: "produce_data.yml"
+          wait: false
+          wait_for_run_url: true
+          json_params: '{"run_id": "${{ github.run_id }}", "run_attempt": "${{ github.run_attempt }}", "sleep": "10" }'

--- a/.github/workflows/demo-tests.yml
+++ b/.github/workflows/demo-tests.yml
@@ -168,11 +168,19 @@ jobs:
           demo_file=$(basename "${{ matrix.path }}")
           python $demo_file
 
+  produce-data:
+    if: always()
+    needs: demo-test
+    uses: ./.github/workflows/produce_data.yml
+    with:
+      run_id: ${{ github.run_id }}
+      run_attempt: ${{ github.run_attempt }}
 
   fail-notify:
     if: always()
     needs:
       - demo-test
+      - produce-data
     runs-on: ubuntu-latest
     outputs:
       is-main: ${{ steps.branch-check.outputs.IS_MAIN }}

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -76,6 +76,7 @@ on:
 # todo(vvukoman): add these permissions to mlir and frontend workflow's that call this wf
 permissions:
   id-token: write
+  actions: write
 
 jobs:
   filter-tests:

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -494,10 +494,20 @@ jobs:
           exit 1
         fi
 
+  produce-data:
+    if: always()
+    needs:
+      - run-perf-benchmarks
+    uses: ./.github/workflows/produce_data.yml
+    with:
+      run_id: ${{ github.run_id }}
+      run_attempt: ${{ github.run_attempt }}
+
   fail-notify:
     if: always()
     needs:
       - run-perf-benchmarks
+      - produce-data
     runs-on: ubuntu-latest
     outputs:
       is-main: ${{ steps.branch-check.outputs.IS_MAIN }}

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -494,20 +494,11 @@ jobs:
           exit 1
         fi
 
-  produce-data:
-    if: always()
-    needs:
-      - run-perf-benchmarks
-    uses: ./.github/workflows/produce_data.yml
-    with:
-      run_id: ${{ github.run_id }}
-      run_attempt: ${{ github.run_attempt }}
 
   fail-notify:
     if: always()
     needs:
       - run-perf-benchmarks
-      - produce-data
     runs-on: ubuntu-latest
     outputs:
       is-main: ${{ steps.branch-check.outputs.IS_MAIN }}
@@ -552,3 +543,20 @@ jobs:
             }
         env:
           SLACK_WEBHOOK_URL: ${{ inputs.slack-token || secrets.SLACK_NIGHTLY_FAIL }}
+
+
+  produce-data:
+    needs:
+      - fail-send-msg
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger produce_data.yml
+        uses: ./.github/actions/trigger-workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
+        with:
+          workflow_name: "produce_data.yml"
+          wait: false
+          wait_for_run_url: true
+          json_params: '{"run_id": "${{ github.run_id }}", "run_attempt": "${{ github.run_attempt }}", "sleep": "10" }'

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -551,6 +551,8 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
+      - name: checkout repository
+        uses: actions/checkout@v4
       - name: Trigger produce_data.yml
         uses: ./.github/actions/trigger-workflow
         env:

--- a/.github/workflows/produce_data.yml
+++ b/.github/workflows/produce_data.yml
@@ -14,7 +14,7 @@ on:
         description: "Run attempt of the workflow to collect data for"
         required: true
         default: ""
-  
+
   workflow_run:
     workflows: # List workflow that we want to collect data for
       - "Performance Benchmark External Trigger"

--- a/.github/workflows/produce_data.yml
+++ b/.github/workflows/produce_data.yml
@@ -2,7 +2,7 @@ name: "[internal] Collect workflow data"
 run-name: "Collect data for run_id ${{ github.event.workflow_run.id }} attempt ${{ github.event.workflow_run.run_attempt }}"
 
 on:
-  workflow_call:
+  workflow_dispatch:
     inputs:
       run_id:
         type: string
@@ -14,6 +14,11 @@ on:
         description: "Run attempt of the workflow to collect data for"
         required: true
         default: ""
+      sleep:
+        type: string
+        description: "Sleep for x seconds before collecting data"
+        required: false
+        default: "0"
 
   workflow_run:
     workflows: # List workflow that we want to collect data for
@@ -27,6 +32,11 @@ jobs:
     env:
         GH_TOKEN: ${{ github.token }}
     steps:
+      #TODO: Added as a temporary fix to avoid race condition between the workflow dispatch and the data collection
+      # https://github.com/tenstorrent/tt-forge/pull/496#issuecomment-3366367292
+      - name: sleep
+        run: |
+          sleep ${{ inputs.sleep || '0' }}
       - name: Collect CI/CD data
         uses: tenstorrent/tt-github-actions/.github/actions/collect_data@main
         with:

--- a/.github/workflows/produce_data.yml
+++ b/.github/workflows/produce_data.yml
@@ -1,5 +1,5 @@
 name: "[internal] Collect workflow data"
-run-name: "Collect data for run_id ${{ github.event.workflow_run.id }} attempt ${{ github.event.workflow_run.run_attempt }} ${{ inputs.parent_run_id && format('parent_run_id:{0}', inputs.parent_run_id) || '' }}"
+run-name: "Collect data for run_id ${{ github.event.workflow_run.id || inputs.run_id }} attempt ${{ github.event.workflow_run.run_attempt || inputs.run_attempt }} ${{ inputs.parent_run_id && format('parent_run_id:{0}', inputs.parent_run_id) || '' }}"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/produce_data.yml
+++ b/.github/workflows/produce_data.yml
@@ -1,5 +1,5 @@
 name: "[internal] Collect workflow data"
-run-name: "Collect data for run_id ${{ github.event.workflow_run.id }} attempt ${{ github.event.workflow_run.run_attempt }}"
+run-name: "Collect data for run_id ${{ github.event.workflow_run.id }} attempt ${{ github.event.workflow_run.run_attempt }} ${{ inputs.parent_run_id && format('parent_run_id:{0}', inputs.parent_run_id) || '' }}"
 
 on:
   workflow_dispatch:
@@ -13,6 +13,11 @@ on:
         type: string
         description: "Run attempt of the workflow to collect data for"
         required: true
+        default: ""
+      parent_run_id:
+        description: "Parent run id is used to track child workflows in automated dispatch workflow calls"
+        required: false
+        type: string
         default: ""
       sleep:
         type: string

--- a/.github/workflows/produce_data.yml
+++ b/.github/workflows/produce_data.yml
@@ -2,11 +2,21 @@ name: "[internal] Collect workflow data"
 run-name: "Collect data for run_id ${{ github.event.workflow_run.id }} attempt ${{ github.event.workflow_run.run_attempt }}"
 
 on:
+  workflow_call:
+    inputs:
+      run_id:
+        type: string
+        description: "Run id of the workflow to collect data for"
+        required: true
+        default: ""
+      run_attempt:
+        type: string
+        description: "Run attempt of the workflow to collect data for"
+        required: true
+        default: ""
+  
   workflow_run:
     workflows: # List workflow that we want to collect data for
-      - "Performance benchmark"
-      - "Nightly Release & Tests"
-      - "Demo tests"
       - "Performance Benchmark External Trigger"
     types:
       - completed
@@ -19,11 +29,10 @@ jobs:
     steps:
       - name: Collect CI/CD data
         uses: tenstorrent/tt-github-actions/.github/actions/collect_data@main
-        if: ${{ github.event_name == 'workflow_run' }}
         with:
           repository: ${{ github.repository }}
-          run_id: ${{ github.event.workflow_run.id }}
-          run_attempt: ${{ github.event.workflow_run.run_attempt }}
+          run_id: ${{ inputs.run_id || github.event.workflow_run.id }}
+          run_attempt: ${{ inputs.run_attempt || github.event.workflow_run.run_attempt }}
           sftp_host: ${{ secrets.SFTP_CICD_WRITER_HOSTNAME }}
           sftp_user: ${{ secrets.SFTP_CICD_WRITER_USERNAME }}
           sftp_perf_host: ${{ secrets.SFTP_PERF_WRITER_HOSTNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,7 +201,7 @@ jobs:
           parent_run_id: "basic-test-${{ steps.set-release-facts.outputs.repo_short }}-${{ steps.set-release-facts.outputs.gh_new_version_tag }}-${{ needs.generate-seed.outputs.random-seed }}"
           wait: false
           wait_for_run_url: true
-          json_params: '{"docker-image": "${{ needs.build-release.outputs.harbor_image_tag }}", "project-filter": "${{ steps.set-release-facts.outputs.repo_short }}" }'
+          json_params: '{"docker-image": "${{ needs.build-release.outputs.harbor_image_tag }}", "project-filter": "${{ steps.set-release-facts.outputs.repo_short }}", "runner-filter": "${{ steps.set-release-facts.outputs.basic_tests_runner_filter }}" }'
 
       - name: Trigger Docker Demo test ${{ steps.set-release-facts.outputs.repo_short }}
         if: ${{  steps.set-release-facts.outputs.skip_docker_build == 'false' }}


### PR DESCRIPTION
Issue:
-  Due to the dynamic nature of  `run-name:` it is preventing us from collecting perf & demo test results.

Changes:
- Update the produce data to be workflow dispatched from the perf & demo workflows before exiting. 
- Increase the default `gh workflow wait` from the default of 3 seconds to 60 seconds to reduce api aggressiveness
- added `runner-filter` to basic test for draft mode only for test workflows due to Civ2 capacity


error logs
```bash
* Basic test tt-torch on tt-ubuntu-2204-p150b-stable (ID 51891779009)
failed to get run: HTTP 403: API rate limit exceeded for installation. If you reach out to GitHub Support for help, please include the request ID D001:5FCED:66C4290:68CDC95:68DFDB39 and timestamp 2025-10-03 14:18:36 UTC. ([https://api.github.com/repos/tenstorrent/tt-forge/actions/runs/18224395008?](https://api.github.com/repos/tenstorrent/tt-forge/actions/runs/18224395008?exclude_pull_requests=true)
```