### PR TITLE
Fix performance tests regression check for frontend uplifts

### DIFF
--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -438,11 +438,10 @@ jobs:
       run: |
         echo "model_name=$(cat ${{ steps.strings.outputs.perf_report_json_file }} | jq -r '.model')" >> $GITHUB_OUTPUT
 
-        #TODO: Add filter here to not pick up draft runs
         workflow_id=$(curl -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
           -H "Accept: application/vnd.github.v3+json" \
-          "https://api.github.com/repos/tenstorrent/tt-forge/actions/workflows/perf-benchmark.yml/runs?status=completed&branch=main&per_page=1&actor=github-actions\[bot\]" \
-          | jq -r '.workflow_runs[0].id')
+          "https://api.github.com/repos/tenstorrent/tt-forge/actions/workflows/perf-benchmark.yml/runs?status=completed&branch=main&per_page=100&actor=github-actions\[bot\]" \
+          | jq -r '.workflow_runs[] | select(.name | contains("draft") | not) | .id' | head -1)
         echo "last_nightly_workflow_id=$workflow_id" >> $GITHUB_OUTPUT
 
     - name: Fetch previous perf results


### PR DESCRIPTION
### Problem
When uplifting tt-mlir in tt-forge-fe we are checking if the changes have introduces regressions in our performance tests.
We used to do that by comparing the results from the Nigthly workflow to the new ones.
Due to the changes in tt-forge's Performance Benchmark workflow this has stopped working properly.

### Solution
Change the parameters for filtering out the desired workflow whose results we use to compare to the new ones.

### Test
Here are Performance Benchmark tests triggered with a regression check from tt-forge-fe: [workflow](https://github.com/tenstorrent/tt-forge-fe/actions/runs/18305865047)