### PR TITLE
Enable perf testing for single containers

### DIFF
--- a/.github/actions/set-release-facts/action.yaml
+++ b/.github/actions/set-release-facts/action.yaml
@@ -200,6 +200,7 @@ runs:
             artifact_cleanup_file_glob='*{.json,benchmark_}*'
             workflow_result_in_job="fail-notify"
             pip_wheel_names="tt_forge_fe tt_tvm"
+            test_perf="true"
         elif [[ "${{ inputs.repo }}" =~ "tt-mlir" ]]; then
             # NOTE: no nightly job current for tt-mlir keeping this here for future use
             workflow="On push"
@@ -218,6 +219,7 @@ runs:
             artifact_download_glob='*{xla-whl-release,test-reports}*'
             pip_wheel_names="pjrt-plugin-tt"
             docker_build_file=".github/Dockerfile.single-wheel-slim-3.11"
+            test_perf="true"
         elif [[ "${{ inputs.repo }}" =~ "tt-forge" ]]; then
             workflow="Daily Releaser"
             ignore_artifacts="true"


### PR DESCRIPTION
This change will run scheduled perf testing on single containers frontends (`tt-forge-fe` & `tt-xla`) so we can compare perf errors between the `tt-forge` unified wheel and the single wheel. 

REF: https://github.com/tenstorrent/tt-forge/issues/512

