### PR TITLE
Fix tt-xla performance tests report

### DIFF
--- a/benchmark/tt-xla/utils.py
+++ b/benchmark/tt-xla/utils.py
@@ -294,7 +294,7 @@ def create_benchmark_result(
         "profile_name": "",
         "input_sequence_length": input_sequence_length,
         "output_sequence_length": -1,
-        "image_dimension": input_is_image,
+        "image_dimension": image_dimension,
         "perf_analysis": False,
         "training": training,
         "measurements": measurements,


### PR DESCRIPTION
### Problem
Since 10.10. performance tests data wasn't uploaded for tt-xla tests.
The issue was that a boolean value was being passed to the `image_dimension` report parameter instead of a string value.

### Solution
Pass the `image_dimension` string to the report.