### PR TITLE
Add version tag to perf & demo test alerts

### DIFF
--- a/.github/workflows/demo-tests.yml
+++ b/.github/workflows/demo-tests.yml
@@ -192,10 +192,18 @@ jobs:
       is-main: ${{ steps.branch-check.outputs.IS_MAIN }}
       failed: ${{ steps.check.outputs.failure }}
       is-draft: ${{ steps.draft-check.outputs.IS_DRAFT }}
+      version_tag: ${{ steps.version-tag.outputs.version_tag }}
     steps:
       - name: Check if branch is main
         id: branch-check
         run: echo "IS_MAIN=$(if [ '${{ github.ref }}' == 'refs/heads/main' ]; then echo true; else echo false; fi)" >> $GITHUB_OUTPUT
+      - name: Get version tag
+        id: version-tag
+        run: |
+          docker_image="${{ inputs.docker-image }}"
+          version_tag="${ docker_image##*: }"
+          echo "version_tag=$version_tag"
+          echo "version_tag=$version_tag" >> $GITHUB_OUTPUT
       - name: Check draft
         id: draft-check
         run: |
@@ -226,7 +234,7 @@ jobs:
         with:
           payload: |
             {
-              "text": "Demo tests ${{ inputs.project-filter }} failed: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}",
+              "text": "Demo tests ${{ inputs.project-filter }} ${{ needs.fail-notify.outputs.version_tag }} failed: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}",
               "channel": "C088QN7E0R3"
             }
         env:

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -497,10 +497,18 @@ jobs:
       is-main: ${{ steps.branch-check.outputs.IS_MAIN }}
       failed: ${{ steps.check.outputs.failure }}
       is-draft: ${{ steps.draft-check.outputs.IS_DRAFT }}
+      version_tag: ${{ steps.version-tag.outputs.version_tag }}
     steps:
       - name: Check if branch is main
         id: branch-check
         run: echo "IS_MAIN=$(if [ '${{ github.ref }}' == 'refs/heads/main' ]; then echo true; else echo false; fi)" >> $GITHUB_OUTPUT
+      - name: Get version tag
+        id: version-tag
+        run: |
+          docker_image="${{ inputs.docker-image }}"
+          version_tag="${ docker_image##*: }"
+          echo "version_tag=$version_tag"
+          echo "version_tag=$version_tag" >> $GITHUB_OUTPUT
       - name: Check draft
         id: draft-check
         run: |
@@ -531,7 +539,7 @@ jobs:
         with:
           payload: |
             {
-              "text": "Perf tests ${{ inputs.project-filter }} failed: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}",
+              "text": "Perf tests ${{ inputs.project-filter }} ${{ needs.fail-notify.outputs.version_tag }} failed: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}",
               "channel": "C088QN7E0R3"
             }
         env:


### PR DESCRIPTION
This adds a version tag to the Slack message so it's easier to tell whether the Nightly build has ran, rather than relying on the Slack client's local timezone. 