### PR TITLE
bug: fix alerts using parameter expansion

### DIFF
--- a/.github/workflows/demo-tests.yml
+++ b/.github/workflows/demo-tests.yml
@@ -175,9 +175,10 @@ jobs:
         run: echo "IS_MAIN=$(if [ '${{ github.ref }}' == 'refs/heads/main' ]; then echo true; else echo false; fi)" >> $GITHUB_OUTPUT
       - name: Get version tag
         id: version-tag
+        shell: bash
         run: |
           docker_image="${{ inputs.docker-image }}"
-          version_tag="${ docker_image##*: }"
+          version_tag="${docker_image##*:}"
           echo "version_tag=$version_tag"
           echo "version_tag=$version_tag" >> $GITHUB_OUTPUT
       - name: Check draft

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -493,10 +493,11 @@ jobs:
         id: branch-check
         run: echo "IS_MAIN=$(if [ '${{ github.ref }}' == 'refs/heads/main' ]; then echo true; else echo false; fi)" >> $GITHUB_OUTPUT
       - name: Get version tag
+        shell: bash
         id: version-tag
         run: |
           docker_image="${{ inputs.docker-image }}"
-          version_tag="${ docker_image##*: }"
+          version_tag="${docker_image##*:}"
           echo "version_tag=$version_tag"
           echo "version_tag=$version_tag" >> $GITHUB_OUTPUT
       - name: Check draft


### PR DESCRIPTION
Fixes issue by using the `shell: bash` instead of the default `shell: sh` that was introduced in https://github.com/tenstorrent/tt-forge/pull/524 along with adjust for spaces

```bash
Run docker_image="ghcr.io/tenstorrent/tt-xla-slim:0.5.0.dev20251015"
  docker_image="ghcr.io/tenstorrent/tt-xla-slim:0.5.0.dev20251015"
  version_tag="${ docker_image##*: }"
  echo "version_tag=$version_tag"
  echo "version_tag=$version_tag" >> $GITHUB_OUTPUT
  shell: /usr/bin/bash -e {0}
/home/runner/work/_temp/66bfd33d-2eb3-46ba-bb07-e82422c635c6.sh: line 2: ${ docker_image##*: }: bad substitution
```

https://github.com/tenstorrent/tt-forge/actions/runs/18517739761/job/52775010162#step:3:8

Local test:

```bash
$ docker_image="ghcr.io/tenstorrent/tt-xla-slim:0.5.0.dev20251015"
$ version_tag="${docker_image##*:}"
$ echo $version_tag
0.5.0.dev20251015
```