### PR TITLE
Change torch to 2.7.0 for resnet jax

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -104,7 +104,7 @@
         "name": "resnet_jax",
         "bs": 8,
         "lp": 4,
-        "pyreq": "pytest tqdm loguru requests transformers ultralytics datasets flax torch"
+        "pyreq": "pytest tqdm loguru requests transformers ultralytics datasets flax torch==2.7.0"
       },
       {
         "name": "resnet",


### PR DESCRIPTION
Jax resnet failed on nightly due to bad torch version.
Set torch version to 2.7.0 like for other models.