### PR TITLE
Add device perf URL to results

### DIFF
--- a/.github/workflows/call-perf-test.yml
+++ b/.github/workflows/call-perf-test.yml
@@ -333,18 +333,29 @@ jobs:
         echo "Run ttrt perf"
         ./benchmark/ttrt_perf.sh ${{ matrix.build.name }}.ttnn ${{ steps.strings.outputs.perf_report_json_file }} || true
 
+    - name: Upload Device Perf separately
+      id: upload-device-perf
+      uses: actions/upload-artifact@v4
+      if: ${{ !matrix.build.skip-device-perf && matrix.build.runs-on != 'p150' }}
+      with:
+        name: device-perf-${{ steps.fetch-job-id.outputs.job_id }}
+        path: ${{ steps.strings.outputs.perf_report_path }}/*.csv
+        compression-level: 0
+
     - name: Add config fields to perf report
       shell: bash
       run: |
         PERF_REPORT_FILE="${{ steps.strings.outputs.perf_report_json_file }}"
         TTIR_URL="${{ !matrix.build.skip-ttir-dump && steps.upload-ttir-mlir.outputs.artifact-url || '' }}"
         TTNN_URL="${{ !matrix.build.skip-ttnn-dump && steps.upload-ttnn-mlir.outputs.artifact-url || '' }}"
+        DEVICE_PERF_URL="${{ !matrix.build.skip-device-perf && matrix.build.runs-on != 'p150' && steps.upload-device-perf.outputs.artifact-url || '' }}"
         MLIR_SHA="${{ steps.find-run.outputs.mlir_sha || '' }}"
         JOB_ID_URL="https://github.com/tenstorrent/tt-forge/actions/runs/${{ github.run_id }}/job/${{ steps.fetch-job-id.outputs.job_id }}"
 
         python benchmark/extend_result_config.py "$PERF_REPORT_FILE" \
           ${TTIR_URL:+--ttir-url "$TTIR_URL"} \
           ${TTNN_URL:+--ttnn-url "$TTNN_URL"} \
+          ${DEVICE_PERF_URL:+--device-perf-url "$DEVICE_PERF_URL"} \
           ${MLIR_SHA:+--mlir-sha "$MLIR_SHA"} \
           --job-id-url "$JOB_ID_URL"
 

--- a/benchmark/extend_result_config.py
+++ b/benchmark/extend_result_config.py
@@ -56,6 +56,7 @@ def main():
     parser.add_argument("--ttir-url", help="URL for the TTIR MLIR artifact")
     parser.add_argument("--ttnn-url", help="URL for the TTNN MLIR artifact")
     parser.add_argument("--mlir-sha", help="MLIR commit SHA")
+    parser.add_argument("--device-perf-url", help="Device perf URL")
     parser.add_argument("--job-id-url", help="Job ID URL")
     parser.add_argument(
         "--config-field",
@@ -77,6 +78,8 @@ def main():
         config_fields["mlir_sha"] = args.mlir_sha
     if args.job_id_url:
         config_fields["job_id_url"] = args.job_id_url
+    if args.device_perf_url:
+        config_fields["device_perf_url"] = args.device_perf_url
 
     if args.config_field:
         for key, value in args.config_field:


### PR DESCRIPTION
Partially closes #400 - adding the URL to superset table required.

Added device perf .csv URL to config field in result json.