### PR TITLE
Disable tt-forge perf test

### DIFF
--- a/.github/actions/set-release-facts/action.yaml
+++ b/.github/actions/set-release-facts/action.yaml
@@ -237,7 +237,6 @@ runs:
             pip_wheel_deps_names="pjrt-plugin-tt tt-forge-fe"
             pip_wheel_names="tt-forge"
             skip_model_compatible_table="true"
-            test_perf="true"
         fi
 
 


### PR DESCRIPTION
This change will only run `tt-xla` &' tt-forge-fe' containers, which will reproduce perf test results to prevent double runs of frontends.

REF: https://github.com/tenstorrent/tt-forge/issues/541#issuecomment-3453995331