### PR TITLE
Add tt-forge dir to Python path in conftest

### DIFF
--- a/benchmark/tt-xla/conftest.py
+++ b/benchmark/tt-xla/conftest.py
@@ -1,7 +1,17 @@
 # SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
+import sys
+import os
 import pytest
+
+# Add tt-forge directory to Python path so imports like 'from benchmark.utils' work
+# when running pytest from any directory (e.g., from tt-xla repo)
+# Path structure: tt-forge/benchmark/tt-xla/conftest.py
+# We need: tt-forge/ in sys.path so 'benchmark' module can be imported
+tt_forge_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+if tt_forge_dir not in sys.path:
+    sys.path.insert(0, tt_forge_dir)
 
 
 # Valid values for parameters


### PR DESCRIPTION
This fix lets us run llms pytest from other places, for example:
```
[/localdev/rpavlovic/tt-xla origin/main] $ LOGGER_LEVEL=DEBUG pytest ../tt-forge/benchmark/tt-xla/llms.py::test_llm --variant llama_3_2_1b_instruct -svv --optimizer-enabled true
```

Ran perf benchmark to verify nothing is broken
https://github.com/tenstorrent/tt-forge/actions/runs/18908135583
