### PR TITLE
Fix segformer input size

### DIFF
--- a/benchmark/tt-xla/segformer.py
+++ b/benchmark/tt-xla/segformer.py
@@ -66,7 +66,7 @@ DATA_FORMAT = [
 
 # Input size configurations
 INPUT_SIZE = [
-    (224, 224),
+    (512, 512),
 ]
 
 # Channel size configurations


### PR DESCRIPTION
https://github.com/tenstorrent/tt-metal/blob/main/models/README.md

According to tt-metal models team's docs, they use 512x512 image input.