### PR TITLE
Performance Benchmark inject mlir_override when triggered from frontends

### DIFF
--- a/.github/workflows/call-perf-test.yml
+++ b/.github/workflows/call-perf-test.yml
@@ -171,7 +171,6 @@ jobs:
           version=$(pip show $project_name | grep -oP "(?<=Version:\s)[\d\.\w]+")
         fi
 
-
         echo "Wheel version: $version"
 
         # TODO: Add tt-mlir version to frontend setup.py description


### PR DESCRIPTION
When triggering the Performance Benchmark workflow from frontends `mlir_override` input could be present and if it is use it explicitily when downloading the specific ttrt version.