### PR TITLE
Change UNet input size

### DIFF
--- a/benchmark/tt-xla/unet.py
+++ b/benchmark/tt-xla/unet.py
@@ -52,7 +52,7 @@ BATCH_SIZE = [
 DATA_FORMAT = ["bfloat16", "float32"]
 
 INPUT_SIZE = [
-    (224, 224),
+    (256, 256),
 ]
 
 CHANNEL_SIZE = [


### PR DESCRIPTION
 ### Ticket
#564

### Problem description
We were using input size 224x224 instead of correct 256x256 for vgg_unet.

### What's changed
Changed input size to 256x256.

This change requires a tt-mlir uplift that includes https://github.com/tenstorrent/tt-mlir/pull/5557 (7c0966781748a1f6a7115ce6ce207d731c795178)