### PR TITLE
feature: pick up wheel by commit id

### DIFF
--- a/.github/actions/build-release-wheel/action.yml
+++ b/.github/actions/build-release-wheel/action.yml
@@ -89,8 +89,11 @@ runs:
       uses: ./.github/actions/uplift-artifacts
       id: uplift-artifacts
       with:
-        repo: ${{ inputs.repo }}
+        repo: ${{ steps.set-release-facts.outputs.repo_full }}
         run-id: ${{ steps.find_workflow_build_release.outputs.run-id }}
+        run-commit-sha: ${{ steps.find_workflow_build_release.outputs.run-commit-sha }}
+        uplift_artifacts_by_commit: ${{ steps.set-release-facts.outputs.uplift_artifacts_by_commit }}
+        artifact_name_prefix: ${{ steps.set-release-facts.outputs.artifact_name_prefix }}
         artifact_download_glob: ${{ steps.set-release-facts.outputs.artifact_download_glob }}
         artifact_cleanup_file_glob: ${{ steps.set-release-facts.outputs.artifact_cleanup_file_glob }}
         artifact_cleanup_folder_glob: ${{ steps.set-release-facts.outputs.artifact_cleanup_folder_glob }}

--- a/.github/actions/set-release-facts/action.yaml
+++ b/.github/actions/set-release-facts/action.yaml
@@ -23,6 +23,7 @@ inputs:
     description: "Latest branch commit"
     required: false
     default: ''
+
 outputs:
   workflow:
     description: "Workflow name"
@@ -120,6 +121,12 @@ outputs:
   basic_tests_runner_filter:
     description: "Basic tests runner filter"
     value: ${{ steps.set-manifest.outputs.basic_tests_runner_filter }}
+  uplift_artifacts_by_commit:
+    description: "Uplift artifacts by commit"
+    value: ${{ steps.set-manifest.outputs.uplift_artifacts_by_commit }}
+  artifact_name_prefix:
+    description: "Artifact name prefix"
+    value: ${{ steps.set-manifest.outputs.artifact_name_prefix }}
 
 runs:
   using: "composite"
@@ -182,6 +189,10 @@ runs:
         python_version="3.11"
         # Filter for which test runners to use for basic tests
         basic_tests_runner_filter="All"
+        # Uplift artifacts by commit
+        uplift_artifacts_by_commit="false"
+        # Artifact name prefix for uplift artifacts by commit
+        artifact_name_prefix=""
 
         # Tag & Release Defaults
 
@@ -223,9 +234,11 @@ runs:
             if [[ "${{ inputs.release_type }}" == "nightly" ]]; then
                 workflow="On push"
             fi
+            artifact_name_prefix="xla-whl-release"
             artifact_download_glob='*{xla-whl-release,test-reports}*'
             pip_wheel_names="pjrt-plugin-tt"
             test_perf="true"
+            uplift_artifacts_by_commit="true"
         elif [[ "${{ inputs.repo }}" =~ "tt-forge" ]]; then
             workflow="Daily Releaser"
             ignore_artifacts="true"
@@ -316,6 +329,8 @@ runs:
         echo "test_perf_sh_runner=$test_perf_sh_runner"
         echo "test_perf=$test_perf"
         echo "basic_tests_runner_filter=$basic_tests_runner_filter"
+        echo "uplift_artifacts_by_commit=$uplift_artifacts_by_commit"
+        echo "artifact_name_prefix=$artifact_name_prefix"
 
         # Set outputs
         echo "workflow=$workflow" >> $GITHUB_OUTPUT
@@ -351,3 +366,5 @@ runs:
         echo "test_perf_sh_runner=$test_perf_sh_runner" >> $GITHUB_OUTPUT
         echo "test_perf=$test_perf" >> $GITHUB_OUTPUT
         echo "basic_tests_runner_filter=$basic_tests_runner_filter" >> $GITHUB_OUTPUT
+        echo "uplift_artifacts_by_commit=$uplift_artifacts_by_commit" >> $GITHUB_OUTPUT
+        echo "artifact_name_prefix=$artifact_name_prefix" >> $GITHUB_OUTPUT

--- a/.github/actions/uplift-artifacts/action.yml
+++ b/.github/actions/uplift-artifacts/action.yml
@@ -21,6 +21,19 @@ inputs:
     description: "Glob to use for deleting extra folders after a artifact is downloaded or exploded"
     type: string
     required: false
+  run-commit-sha:
+    description: "Commit sha of the workflow"
+    type: string
+    required: false
+  uplift_artifacts_by_commit:
+    description: "Uplift artifacts by commit"
+    type: string
+    required: true
+    default: "false"
+  artifact_name_prefix:
+    description: "Artifact name prefix"
+    type: string
+    required: true
 
 outputs:
   download-path:
@@ -30,13 +43,34 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Check if artifact exists
+      if: ${{ inputs.uplift_artifacts_by_commit == 'true' }}
+      id: check-artifact
+      shell: bash
+      run: |
+        # TODO: convert the commit sha to short sha for artifact name download
+        short_sha=$(git rev-parse --short ${{ inputs.run-commit-sha }})
+        artifact_name="${{ inputs.artifact_name_prefix }}-${short_sha}"
+        # Use GitHub API to check for existing artifacts
+        response=$(curl -s -H "Authorization: token ${{ github.token }}" \
+          "https://api.github.com/repos/${{ inputs.repo }}/actions/artifacts?name=${artifact_name}")
+        total_count=$(echo "$response" | jq -r '.total_count')
+
+        if [ "$total_count" -lt 1 ]; then
+          echo "No existing artifact found for: $artifact_name"
+          exit 1
+        fi
+        artifacts_run_id=$(echo "$response" | jq -r '.artifacts[0].workflow_run.id')
+        echo "artifacts_run_id=${artifacts_run_id}" >> "$GITHUB_OUTPUT"
+        echo "Found existing artifact: $artifact_name"
     - name: Download artifacts
       id: artifacts
       uses: actions/download-artifact@v4
       with:
         repository: ${{ inputs.repo }}
         pattern: ${{ inputs.artifact_download_glob }}
-        run-id: ${{ inputs.run-id }}
+        # Prefer the existing artifact run id if it exists, otherwise use the provided run id
+        run-id: ${{ steps.check-artifact.outputs.artifacts_run_id || inputs.run-id }}
         github-token: ${{ github.token }}
         path: ${{ github.workspace }}/release/artifacts/${{ inputs.repo }}
     - name: Explode and clean up artifact path


### PR DESCRIPTION
Solves task 1 of https://github.com/tenstorrent/tt-forge/issues/585, by adding a new artifact pick-up method based on commit.
> xla-whl-release artifact will be needed to add an artifact to [schedule-nightly.yml](https://github.com/tenstorrent/tt-xla/blob/main/.github/workflows/schedule-nightly.yml) for wheel artifact pickup.

This supersedes PR:
https://github.com/tenstorrent/tt-xla/pull/2018