### PR TITLE
Fix Llama versions.

### DIFF
--- a/benchmark/tt-xla/llm_benchmark.py
+++ b/benchmark/tt-xla/llm_benchmark.py
@@ -46,17 +46,18 @@ DEFAULT_INPUT_PROMPT = "Here is an exaustive list of the best practices for writ
 MODULE_EXPORT_PATH = "modules"
 
 
-def setup_model_and_tokenizer(model_loader) -> tuple[torch.nn.Module, PreTrainedTokenizer]:
+def setup_model_and_tokenizer(model_loader, model_variant) -> tuple[torch.nn.Module, PreTrainedTokenizer]:
     """
     Instantiate model and tokenizer.
 
     Args:
-        model_name: HuggingFace model name
+        model_loader: Loader of the HuggingFace model.
+        model_variant: Specific variant of the model.
 
     Returns:
         Tuple of (model, tokenizer)
     """
-    print(f"Loading model {model_loader.get_model_info().name}...")
+    print(f"Loading model {model_loader.get_model_info(variant=model_variant).name}...")
 
     model = model_loader.load_model(dtype_override=torch.bfloat16)
     model = model.eval()
@@ -227,6 +228,7 @@ def check_transformers_version():
 
 def benchmark_llm_torch_xla(
     model_loader,
+    model_variant,
     optimizer_enabled,
     memory_layout_analysis,
     trace_enabled,
@@ -285,7 +287,7 @@ def benchmark_llm_torch_xla(
     device: torch.device = xm.xla_device()
 
     # Instantiate model and tokenizer
-    model, tokenizer = setup_model_and_tokenizer(model_loader)
+    model, tokenizer = setup_model_and_tokenizer(model_loader, model_variant)
 
     # Construct inputs, including static cache
     input_args = construct_inputs(input_prompt, tokenizer, model.config, batch_size, max_cache_len)
@@ -384,7 +386,7 @@ def benchmark_llm_torch_xla(
 
     metadata = get_benchmark_metadata()
 
-    full_model_name = model_loader.get_model_info().name
+    full_model_name = model_loader.get_model_info(variant=model_variant).name
     model_type = "text-generation"
     dataset_name = "Random Data"
 

--- a/benchmark/tt-xla/llms.py
+++ b/benchmark/tt-xla/llms.py
@@ -95,7 +95,8 @@ def test_llm(
 
     if ModelVariant(variant) not in ModelLoader.query_available_variants():
         raise ValueError(f"Variant {variant} is not available for the specified model.")
-    model_loader = ModelLoader(variant=ModelVariant(variant))
+    model_variant = ModelVariant(variant)
+    model_loader = ModelLoader(variant=model_variant)
 
     # Get config values for the model in the following order of precedence:
     # 1. Command line argument (if provided)
@@ -147,6 +148,7 @@ def test_llm(
         memory_layout_analysis=memory_layout_analysis,
         trace_enabled=trace_enabled,
         model_loader=model_loader,
+        model_variant=model_variant,
         batch_size=batch_size,
         loop_count=loop_count,
         task=task,
@@ -159,7 +161,7 @@ def test_llm(
 
     if output:
         results["project"] = "tt-forge/tt-xla"
-        results["model_rawname"] = model_loader.get_model_info().name
+        results["model_rawname"] = model_loader.get_model_info(variant=model_variant).name
 
         with open(output, "w") as file:
             json.dump(results, file, indent=2)


### PR DESCRIPTION
When we get information about the model name we don't pass model variant, so the model always uses default version/variant. That causes wrong name in the database and rewriting previously preserved information, [issue](https://github.com/tenstorrent/tt-forge/issues/555).

This PR is fix for that problem. Tested locally on Llama models.