### PR TITLE
Update default optimization level to 1 for LLM benchmarks

### DIFF
--- a/benchmark/tt-xla/llms.py
+++ b/benchmark/tt-xla/llms.py
@@ -9,7 +9,7 @@ import os
 from llm_benchmark import benchmark_llm_torch_xla
 
 # Defaults for all llms
-OPTIMIZATION_LEVEL = 0
+OPTIMIZATION_LEVEL = 1
 TRACE_ENABLED = False
 BATCH_SIZE = 32
 LOOP_COUNT = 1


### PR DESCRIPTION
### Ticket
N/A

### Problem description
The default optimization level for LLM benchmarks was set to 0, which doesn't apply optimizations that could improve performance.

### What's changed
- Updated `OPTIMIZATION_LEVEL` from 0 to 1 in `benchmark/tt-xla/llms.py`
- This enables basic compiler optimizations for all LLM benchmarks by default

### Checklist
- [x] New/Existing tests provide coverage for changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)