### PR TITLE
Dump generated IR modules even when compile and run fails

### DIFF
--- a/.github/workflows/call-perf-test.yml
+++ b/.github/workflows/call-perf-test.yml
@@ -196,11 +196,10 @@ jobs:
           pytest -svv "${{ matrix.build.pytest }}" --variant ${{ matrix.build.variant }} --output=${{ steps.strings.outputs.perf_report_json_file }} $PYTEST_OPTS
         fi
 
-    - name: Dump ttir and ttnn to report
-      if: ${{ !matrix.build.skip-ttir-dump && !matrix.build.skip-ttnn-dump }}
+    - name: Dump ttir to report
+      if: (success() || failure()) && !matrix.build.skip-ttir-dump
       shell: bash
       run: |
-
         echo "Dump ttir to report"
         mkdir -p ${{ steps.strings.outputs.perf_report_path }}/ttir
         if [ "${{ matrix.build.project }}" == "tt-xla" ]; then
@@ -213,6 +212,18 @@ jobs:
           cp ~/testify/ll-sw/${{ matrix.build.dir }}/mlir_reports/ttir.mlir ${{ steps.strings.outputs.perf_report_path }}/ttir/ttir.mlir
         fi
 
+    - name: Upload TTIR MLIR separately
+      id: upload-ttir-mlir
+      uses: actions/upload-artifact@v4
+      if: (success() || failure()) && !matrix.build.skip-ttir-dump
+      with:
+        name: ttir-mlir-${{ steps.fetch-job-id.outputs.job_id }}
+        path: ${{ steps.strings.outputs.perf_report_path }}/ttir/
+
+    - name: Dump ttnn to report
+      if: (success() || failure()) && !matrix.build.skip-ttnn-dump
+      shell: bash
+      run: |
         echo "Dump ttnn to report"
         mkdir -p ${{ steps.strings.outputs.perf_report_path }}/ttnn
         if [ "${{ matrix.build.project }}" == "tt-xla" ]; then
@@ -225,18 +236,10 @@ jobs:
           cp ~/testify/ll-sw/${{ matrix.build.dir }}/mlir_reports/ttnn.mlir ${{ steps.strings.outputs.perf_report_path }}/ttnn/ttnn.mlir
         fi
 
-    - name: Upload TTIR MLIR separately
-      id: upload-ttir-mlir
-      uses: actions/upload-artifact@v4
-      if: ${{ !matrix.build.skip-ttir-dump }}
-      with:
-        name: ttir-mlir-${{ steps.fetch-job-id.outputs.job_id }}
-        path: ${{ steps.strings.outputs.perf_report_path }}/ttir/
-
     - name: Upload TTNN MLIR separately
       id: upload-ttnn-mlir
       uses: actions/upload-artifact@v4
-      if: ${{ !matrix.build.skip-ttnn-dump }}
+      if: (success() || failure()) && !matrix.build.skip-ttnn-dump
       with:
         name: ttnn-mlir-${{ steps.fetch-job-id.outputs.job_id }}
         path: ${{ steps.strings.outputs.perf_report_path }}/ttnn/


### PR DESCRIPTION
Currently, jobs that dump ttir and ttnn are skipped when Run perf benchmark fails. 
This PR enables dumping modules generated prior to failure in compile or runtime.