### PR TITLE
Enable experimental BFP8 weight conversion for tt-xla benchmarks

### DIFF
--- a/benchmark/tt-xla/bge_m3_encode.py
+++ b/benchmark/tt-xla/bge_m3_encode.py
@@ -34,6 +34,7 @@ os.environ["XLA_STABLEHLO_COMPILE"] = "1"
 OPTIMIZATION_LEVEL = 0
 PROGRAM_CACHE_ENABLED = True
 TRACE_ENABLED = False
+ENABLE_WEIGHT_BFP8_CONVERSION = True
 
 if PROGRAM_CACHE_ENABLED:
     os.environ["TT_RUNTIME_ENABLE_PROGRAM_CACHE"] = "1"
@@ -318,6 +319,7 @@ def test_bge_m3_encode_torch_xla(
         "export_path": MODULE_EXPORT_PATH,
         "ttnn_perf_metrics_enabled": True,
         "ttnn_perf_metrics_output_file": ttnn_perf_metrics_output_file,
+        "experimental_enable_weight_bfp8_conversion": ENABLE_WEIGHT_BFP8_CONVERSION,
     }
 
     torch_xla.set_custom_compile_options(options)
@@ -401,6 +403,7 @@ def test_bge_m3_encode_torch_xla(
         optimization_level=OPTIMIZATION_LEVEL,
         program_cache_enabled=PROGRAM_CACHE_ENABLED,
         trace_enabled=TRACE_ENABLED,
+        enable_weight_bfp8_conversion=ENABLE_WEIGHT_BFP8_CONVERSION,
         model_info="BAAI/bge-m3",
         torch_xla_enabled=True,
         backend="tt",

--- a/benchmark/tt-xla/efficientnet.py
+++ b/benchmark/tt-xla/efficientnet.py
@@ -12,6 +12,7 @@ import socket
 OPTIMIZATION_LEVEL = 2
 PROGRAM_CACHE_ENABLED = True
 TRACE_ENABLED = False
+ENABLE_WEIGHT_BFP8_CONVERSION = False
 
 if PROGRAM_CACHE_ENABLED:
     os.environ["TT_RUNTIME_ENABLE_PROGRAM_CACHE"] = "1"
@@ -158,6 +159,7 @@ def test_efficientnet_torch_xla(
         "export_path": MODULE_EXPORT_PATH,
         "ttnn_perf_metrics_enabled": True,
         "ttnn_perf_metrics_output_file": ttnn_perf_metrics_output_file,
+        "experimental_enable_weight_bfp8_conversion": ENABLE_WEIGHT_BFP8_CONVERSION,
     }
 
     torch_xla.set_custom_compile_options(options)
@@ -241,6 +243,7 @@ def test_efficientnet_torch_xla(
         optimization_level=OPTIMIZATION_LEVEL,
         program_cache_enabled=PROGRAM_CACHE_ENABLED,
         trace_enabled=TRACE_ENABLED,
+        enable_weight_bfp8_conversion=ENABLE_WEIGHT_BFP8_CONVERSION,
         model_info=model_info,
         torch_xla_enabled=True,
         backend="tt",

--- a/benchmark/tt-xla/llm_benchmark.py
+++ b/benchmark/tt-xla/llm_benchmark.py
@@ -237,6 +237,7 @@ def benchmark_llm_torch_xla(
     measure_cpu,
     input_sequence_length,
     experimental_compile,
+    enable_weight_bfp8_conversion,
     ttnn_perf_metrics_output_file,
     read_logits_fn,
 ):
@@ -340,6 +341,7 @@ def benchmark_llm_torch_xla(
         "export_path": MODULE_EXPORT_PATH,
         "ttnn_perf_metrics_enabled": True,
         "ttnn_perf_metrics_output_file": ttnn_perf_metrics_output_file,
+        "experimental_enable_weight_bfp8_conversion": enable_weight_bfp8_conversion,
     }
 
     torch_xla.set_custom_compile_options(options)
@@ -442,6 +444,7 @@ def benchmark_llm_torch_xla(
         optimization_level=optimization_level,
         program_cache_enabled=PROGRAM_CACHE_ENABLED,
         trace_enabled=trace_enabled,
+        enable_weight_bfp8_conversion=enable_weight_bfp8_conversion,
         model_info=full_model_name,
         torch_xla_enabled=True,
         backend="tt",

--- a/benchmark/tt-xla/llms.py
+++ b/benchmark/tt-xla/llms.py
@@ -19,6 +19,7 @@ DEFAULT_DATA_FORMAT = "bfloat16"
 DEFAULT_MEASURE_CPU = False
 DEFAULT_TASK = "text-generation"
 DEFAULT_EXPERIMENTAL_COMPILE = True
+DEFAULT_ENABLE_WEIGHT_BFP8_CONVERSION = True
 
 
 def default_read_logits_fn(output):
@@ -38,6 +39,7 @@ def test_llm(
     measure_cpu=DEFAULT_MEASURE_CPU,
     task=DEFAULT_TASK,
     experimental_compile=DEFAULT_EXPERIMENTAL_COMPILE,
+    enable_weight_bfp8_conversion=DEFAULT_ENABLE_WEIGHT_BFP8_CONVERSION,
     read_logits_fn=default_read_logits_fn,
 ):
     """Test LLM model with the given variant and optional configuration overrides.
@@ -54,6 +56,7 @@ def test_llm(
         measure_cpu: Measure CPU FPS
         task: Task type
         experimental_compile: Enable experimental compile
+        enable_weight_bfp8_conversion: Enable BFP8 weight conversion
         read_logits_fn: Function to extract logits from model output
     """
     model_loader = ModelLoaderModule(variant=variant)
@@ -71,6 +74,7 @@ def test_llm(
     measure_cpu={measure_cpu}
     task={task}
     experimental_compile={experimental_compile}
+    enable_weight_bfp8_conversion={enable_weight_bfp8_conversion}
     ttnn_perf_metrics_output_file={ttnn_perf_metrics_output_file}
     """
     )
@@ -88,6 +92,7 @@ def test_llm(
         input_sequence_length=input_sequence_length,
         training=False,
         experimental_compile=experimental_compile,
+        enable_weight_bfp8_conversion=enable_weight_bfp8_conversion,
         ttnn_perf_metrics_output_file=ttnn_perf_metrics_output_file,
         read_logits_fn=read_logits_fn,
     )
@@ -125,7 +130,8 @@ def test_llama_3_2_3b(output):
     from third_party.tt_forge_models.llama.causal_lm.pytorch.loader import ModelLoader, ModelVariant
 
     variant = ModelVariant.LLAMA_3_2_3B_INSTRUCT
-    test_llm(ModelLoaderModule=ModelLoader, variant=variant, output=output)
+    # Disable BFP8 weight conversion due to OOM failure
+    test_llm(ModelLoaderModule=ModelLoader, variant=variant, output=output, enable_weight_bfp8_conversion=False)
 
 
 def test_gemma_1_1_2b(output):
@@ -133,7 +139,14 @@ def test_gemma_1_1_2b(output):
 
     variant = ModelVariant.GEMMA_1_1_2B_IT
     experimental_compile = False
-    test_llm(ModelLoaderModule=ModelLoader, variant=variant, output=output, experimental_compile=experimental_compile)
+    # Disable BFP8 weight conversion due to OOM failure
+    test_llm(
+        ModelLoaderModule=ModelLoader,
+        variant=variant,
+        output=output,
+        experimental_compile=experimental_compile,
+        enable_weight_bfp8_conversion=False,
+    )
 
 
 def test_gemma_2_2b(output):
@@ -163,7 +176,14 @@ def test_phi2(output):
 
     variant = ModelVariant.PHI2
     # Disable optimizer for phi2 due to PCC issue
-    test_llm(ModelLoaderModule=ModelLoader, optimization_level=0, variant=variant, output=output)
+    # Disable BFP8 weight conversion due to OOM failure
+    test_llm(
+        ModelLoaderModule=ModelLoader,
+        optimization_level=0,
+        variant=variant,
+        output=output,
+        enable_weight_bfp8_conversion=False,
+    )
 
 
 def test_falcon3_1b(output):
@@ -181,7 +201,14 @@ def test_falcon3_3b(output):
     variant = ModelVariant.FALCON_3B
     # Tuple format: (logits, past_key_values, ...)
     read_logits_fn = lambda output: output[0]
-    test_llm(ModelLoaderModule=ModelLoader, variant=variant, output=output, read_logits_fn=read_logits_fn)
+    # Disable BFP8 weight conversion due to OOM failure
+    test_llm(
+        ModelLoaderModule=ModelLoader,
+        variant=variant,
+        output=output,
+        read_logits_fn=read_logits_fn,
+        enable_weight_bfp8_conversion=False,
+    )
 
 
 def test_qwen_2_5_0_5b(output):
@@ -209,4 +236,5 @@ def test_qwen_3_4b(output):
     from third_party.tt_forge_models.qwen_3.causal_lm.pytorch.loader import ModelLoader, ModelVariant
 
     variant = ModelVariant.QWEN_3_4B
-    test_llm(ModelLoaderModule=ModelLoader, variant=variant, output=output)
+    # Disable BFP8 weight conversion due to OOM failure
+    test_llm(ModelLoaderModule=ModelLoader, variant=variant, output=output, enable_weight_bfp8_conversion=False)

--- a/benchmark/tt-xla/mnist.py
+++ b/benchmark/tt-xla/mnist.py
@@ -12,6 +12,7 @@ import socket
 OPTIMIZATION_LEVEL = 2
 PROGRAM_CACHE_ENABLED = True
 TRACE_ENABLED = False
+ENABLE_WEIGHT_BFP8_CONVERSION = True
 
 if PROGRAM_CACHE_ENABLED:
     os.environ["TT_RUNTIME_ENABLE_PROGRAM_CACHE"] = "1"
@@ -155,6 +156,7 @@ def test_mnist_torch_xla(
         "export_path": MODULE_EXPORT_PATH,
         "ttnn_perf_metrics_enabled": True,
         "ttnn_perf_metrics_output_file": ttnn_perf_metrics_output_file,
+        "experimental_enable_weight_bfp8_conversion": ENABLE_WEIGHT_BFP8_CONVERSION,
     }
 
     torch_xla.set_custom_compile_options(options)
@@ -239,6 +241,7 @@ def test_mnist_torch_xla(
         optimization_level=OPTIMIZATION_LEVEL,
         program_cache_enabled=PROGRAM_CACHE_ENABLED,
         trace_enabled=TRACE_ENABLED,
+        enable_weight_bfp8_conversion=ENABLE_WEIGHT_BFP8_CONVERSION,
         model_info=model_info,
         torch_xla_enabled=True,
         backend="tt",

--- a/benchmark/tt-xla/mobilenetv2.py
+++ b/benchmark/tt-xla/mobilenetv2.py
@@ -12,6 +12,7 @@ import socket
 OPTIMIZATION_LEVEL = 2
 PROGRAM_CACHE_ENABLED = True
 TRACE_ENABLED = False
+ENABLE_WEIGHT_BFP8_CONVERSION = False
 
 if PROGRAM_CACHE_ENABLED:
     os.environ["TT_RUNTIME_ENABLE_PROGRAM_CACHE"] = "1"
@@ -158,6 +159,7 @@ def test_mobilenetv2_torch_xla(
         "export_path": MODULE_EXPORT_PATH,
         "ttnn_perf_metrics_enabled": True,
         "ttnn_perf_metrics_output_file": ttnn_perf_metrics_output_file,
+        "experimental_enable_weight_bfp8_conversion": ENABLE_WEIGHT_BFP8_CONVERSION,
     }
 
     torch_xla.set_custom_compile_options(options)
@@ -242,6 +244,7 @@ def test_mobilenetv2_torch_xla(
         optimization_level=OPTIMIZATION_LEVEL,
         program_cache_enabled=PROGRAM_CACHE_ENABLED,
         trace_enabled=TRACE_ENABLED,
+        enable_weight_bfp8_conversion=ENABLE_WEIGHT_BFP8_CONVERSION,
         model_info=model_info,
         torch_xla_enabled=True,
         backend="tt",

--- a/benchmark/tt-xla/resnet.py
+++ b/benchmark/tt-xla/resnet.py
@@ -12,6 +12,7 @@ import socket
 OPTIMIZATION_LEVEL = 2
 PROGRAM_CACHE_ENABLED = True
 TRACE_ENABLED = False
+ENABLE_WEIGHT_BFP8_CONVERSION = True
 
 if PROGRAM_CACHE_ENABLED:
     os.environ["TT_RUNTIME_ENABLE_PROGRAM_CACHE"] = "1"
@@ -161,6 +162,7 @@ def test_resnet_torch_xla(
         "export_path": MODULE_EXPORT_PATH,
         "ttnn_perf_metrics_enabled": True,
         "ttnn_perf_metrics_output_file": ttnn_perf_metrics_output_file,
+        "experimental_enable_weight_bfp8_conversion": ENABLE_WEIGHT_BFP8_CONVERSION,
     }
 
     torch_xla.set_custom_compile_options(options)
@@ -245,6 +247,7 @@ def test_resnet_torch_xla(
         optimization_level=OPTIMIZATION_LEVEL,
         program_cache_enabled=PROGRAM_CACHE_ENABLED,
         trace_enabled=TRACE_ENABLED,
+        enable_weight_bfp8_conversion=ENABLE_WEIGHT_BFP8_CONVERSION,
         model_info=model_info,
         torch_xla_enabled=True,
         backend="tt",

--- a/benchmark/tt-xla/resnet_jax.py
+++ b/benchmark/tt-xla/resnet_jax.py
@@ -26,6 +26,7 @@ from benchmark.utils import get_jax_device_arch
 OPTIMIZATION_LEVEL = 1
 PROGRAM_CACHE_ENABLED = False
 TRACE_ENABLED = False
+ENABLE_WEIGHT_BFP8_CONVERSION = False
 
 
 BATCH_SIZE = [
@@ -145,6 +146,7 @@ def test_resnet(
         optimization_level=OPTIMIZATION_LEVEL,
         program_cache_enabled=PROGRAM_CACHE_ENABLED,
         trace_enabled=TRACE_ENABLED,
+        enable_weight_bfp8_conversion=ENABLE_WEIGHT_BFP8_CONVERSION,
         model_info=model_info,
         torch_xla_enabled=False,
         channel_size=channel_size,

--- a/benchmark/tt-xla/segformer.py
+++ b/benchmark/tt-xla/segformer.py
@@ -12,6 +12,7 @@ import socket
 OPTIMIZATION_LEVEL = 2
 PROGRAM_CACHE_ENABLED = True
 TRACE_ENABLED = False
+ENABLE_WEIGHT_BFP8_CONVERSION = True
 
 if PROGRAM_CACHE_ENABLED:
     os.environ["TT_RUNTIME_ENABLE_PROGRAM_CACHE"] = "1"
@@ -158,6 +159,7 @@ def test_segformer_torch_xla(
         "export_path": MODULE_EXPORT_PATH,
         "ttnn_perf_metrics_enabled": True,
         "ttnn_perf_metrics_output_file": ttnn_perf_metrics_output_file,
+        "experimental_enable_weight_bfp8_conversion": ENABLE_WEIGHT_BFP8_CONVERSION,
     }
 
     torch_xla.set_custom_compile_options(options)
@@ -242,6 +244,7 @@ def test_segformer_torch_xla(
         optimization_level=OPTIMIZATION_LEVEL,
         program_cache_enabled=PROGRAM_CACHE_ENABLED,
         trace_enabled=TRACE_ENABLED,
+        enable_weight_bfp8_conversion=ENABLE_WEIGHT_BFP8_CONVERSION,
         model_info=model_info,
         torch_xla_enabled=True,
         backend="tt",

--- a/benchmark/tt-xla/swin.py
+++ b/benchmark/tt-xla/swin.py
@@ -12,6 +12,7 @@ import socket
 OPTIMIZATION_LEVEL = 2
 PROGRAM_CACHE_ENABLED = True
 TRACE_ENABLED = False
+ENABLE_WEIGHT_BFP8_CONVERSION = False
 
 if PROGRAM_CACHE_ENABLED:
     os.environ["TT_RUNTIME_ENABLE_PROGRAM_CACHE"] = "1"
@@ -158,6 +159,7 @@ def test_swin_torch_xla(
         "export_path": MODULE_EXPORT_PATH,
         "ttnn_perf_metrics_enabled": True,
         "ttnn_perf_metrics_output_file": ttnn_perf_metrics_output_file,
+        "experimental_enable_weight_bfp8_conversion": ENABLE_WEIGHT_BFP8_CONVERSION,
     }
 
     torch_xla.set_custom_compile_options(options)
@@ -242,6 +244,7 @@ def test_swin_torch_xla(
         optimization_level=OPTIMIZATION_LEVEL,
         program_cache_enabled=PROGRAM_CACHE_ENABLED,
         trace_enabled=TRACE_ENABLED,
+        enable_weight_bfp8_conversion=ENABLE_WEIGHT_BFP8_CONVERSION,
         model_info=model_info,
         torch_xla_enabled=True,
         backend="tt",

--- a/benchmark/tt-xla/ufld.py
+++ b/benchmark/tt-xla/ufld.py
@@ -11,6 +11,7 @@ import socket
 OPTIMIZATION_LEVEL = 2
 PROGRAM_CACHE_ENABLED = True
 TRACE_ENABLED = False
+ENABLE_WEIGHT_BFP8_CONVERSION = True
 
 if PROGRAM_CACHE_ENABLED:
     os.environ["TT_RUNTIME_ENABLE_PROGRAM_CACHE"] = "1"
@@ -154,6 +155,7 @@ def test_ufld_torch_xla(
         "export_path": "modules",
         "ttnn_perf_metrics_enabled": True,
         "ttnn_perf_metrics_output_file": ttnn_perf_metrics_output_file,
+        "experimental_enable_weight_bfp8_conversion": ENABLE_WEIGHT_BFP8_CONVERSION,
     }
 
     torch_xla.set_custom_compile_options(options)
@@ -235,6 +237,7 @@ def test_ufld_torch_xla(
         optimization_level=OPTIMIZATION_LEVEL,
         program_cache_enabled=PROGRAM_CACHE_ENABLED,
         trace_enabled=TRACE_ENABLED,
+        enable_weight_bfp8_conversion=ENABLE_WEIGHT_BFP8_CONVERSION,
         model_info=model_info,
         torch_xla_enabled=True,
         backend="tt",

--- a/benchmark/tt-xla/unet.py
+++ b/benchmark/tt-xla/unet.py
@@ -12,6 +12,7 @@ import socket
 OPTIMIZATION_LEVEL = 2
 PROGRAM_CACHE_ENABLED = True
 TRACE_ENABLED = False
+ENABLE_WEIGHT_BFP8_CONVERSION = True
 
 if PROGRAM_CACHE_ENABLED:
     os.environ["TT_RUNTIME_ENABLE_PROGRAM_CACHE"] = "1"
@@ -131,6 +132,7 @@ def test_unet_torch_xla(
         "export_path": MODULE_EXPORT_PATH,
         "ttnn_perf_metrics_enabled": True,
         "ttnn_perf_metrics_output_file": ttnn_perf_metrics_output_file,
+        "experimental_enable_weight_bfp8_conversion": ENABLE_WEIGHT_BFP8_CONVERSION,
     }
 
     torch_xla.set_custom_compile_options(options)
@@ -206,6 +208,7 @@ def test_unet_torch_xla(
         optimization_level=OPTIMIZATION_LEVEL,
         program_cache_enabled=PROGRAM_CACHE_ENABLED,
         trace_enabled=TRACE_ENABLED,
+        enable_weight_bfp8_conversion=ENABLE_WEIGHT_BFP8_CONVERSION,
         model_info=model_info,
         torch_xla_enabled=True,
         backend="tt",

--- a/benchmark/tt-xla/utils.py
+++ b/benchmark/tt-xla/utils.py
@@ -213,6 +213,7 @@ def create_benchmark_result(
     optimization_level: int = 0,
     program_cache_enabled: bool = False,
     trace_enabled: bool = False,
+    enable_weight_bfp8_conversion: bool = False,
     model_info: str = "",
     torch_xla_enabled: bool = True,
     backend: str = "tt",
@@ -266,6 +267,7 @@ def create_benchmark_result(
         "optimization_level": optimization_level,
         "program_cache_enabled": program_cache_enabled,
         "trace_enabled": trace_enabled,
+        "enable_weight_bfp8_conversion": enable_weight_bfp8_conversion,
         "model_info": model_info,
     }
 

--- a/benchmark/tt-xla/vit.py
+++ b/benchmark/tt-xla/vit.py
@@ -12,6 +12,7 @@ import socket
 OPTIMIZATION_LEVEL = 2
 PROGRAM_CACHE_ENABLED = True
 TRACE_ENABLED = False
+ENABLE_WEIGHT_BFP8_CONVERSION = True
 
 if PROGRAM_CACHE_ENABLED:
     os.environ["TT_RUNTIME_ENABLE_PROGRAM_CACHE"] = "1"
@@ -158,6 +159,7 @@ def test_vit_torch_xla(
         "export_path": MODULE_EXPORT_PATH,
         "ttnn_perf_metrics_enabled": True,
         "ttnn_perf_metrics_output_file": ttnn_perf_metrics_output_file,
+        "experimental_enable_weight_bfp8_conversion": ENABLE_WEIGHT_BFP8_CONVERSION,
     }
 
     torch_xla.set_custom_compile_options(options)
@@ -242,6 +244,7 @@ def test_vit_torch_xla(
         optimization_level=OPTIMIZATION_LEVEL,
         program_cache_enabled=PROGRAM_CACHE_ENABLED,
         trace_enabled=TRACE_ENABLED,
+        enable_weight_bfp8_conversion=ENABLE_WEIGHT_BFP8_CONVERSION,
         model_info=model_info,
         torch_xla_enabled=True,
         backend="tt",

--- a/benchmark/tt-xla/vovnet.py
+++ b/benchmark/tt-xla/vovnet.py
@@ -12,6 +12,7 @@ import socket
 OPTIMIZATION_LEVEL = 2
 PROGRAM_CACHE_ENABLED = True
 TRACE_ENABLED = False
+ENABLE_WEIGHT_BFP8_CONVERSION = True
 
 if PROGRAM_CACHE_ENABLED:
     os.environ["TT_RUNTIME_ENABLE_PROGRAM_CACHE"] = "1"
@@ -158,6 +159,7 @@ def test_vovnet_torch_xla(
         "export_path": MODULE_EXPORT_PATH,
         "ttnn_perf_metrics_enabled": True,
         "ttnn_perf_metrics_output_file": ttnn_perf_metrics_output_file,
+        "experimental_enable_weight_bfp8_conversion": ENABLE_WEIGHT_BFP8_CONVERSION,
     }
 
     torch_xla.set_custom_compile_options(options)
@@ -241,6 +243,7 @@ def test_vovnet_torch_xla(
         optimization_level=OPTIMIZATION_LEVEL,
         program_cache_enabled=PROGRAM_CACHE_ENABLED,
         trace_enabled=TRACE_ENABLED,
+        enable_weight_bfp8_conversion=ENABLE_WEIGHT_BFP8_CONVERSION,
         model_info=model_info,
         torch_xla_enabled=True,
         backend="tt",


### PR DESCRIPTION
### Problem description
Enable the experimental BFP8 weight conversion feature for all tt-xla benchmark models to evaluate performance impact.

### What's changed
Added `experimental_enable_weight_bfp8_conversion: "true"` to the compile options for all tt-xla benchmark which do not run into OOM.

### Checklist
- [ ] New/Existing tests provide coverage for changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)