### PR TITLE
Add the check-all-green job to On PR

### DIFF
--- a/.github/workflows/pr-main.yml
+++ b/.github/workflows/pr-main.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   performance-benchmark:
     uses: ./.github/workflows/perf-benchmark.yml
-    # if: contains(github.event.pull_request.labels.*.name, 'uplift')
+    if: contains(github.event.pull_request.labels.*.name, 'uplift')
     secrets: inherit
     with:
       docker-image: ghcr.io/tenstorrent/tt-xla-slim:nightly-latest


### PR DESCRIPTION
### Problem
Uplift of tt-forge-models -> tt-forge needs to do these things: 
1. Auto-merge the PR
2. Run the `Performance Benchmark` workflow
3. `Performance Benchmark` workflow can fail because it is currently unstable but we still want to track regressions
4.  Remove the uplift branch after a merge into main


Auto-merge needs to happen after the `Performance Benchmark` is done becuase if it happens earlier the branch will be removed and Performance Benchmark will try to checkout a removed ref.

### Solution
Introduce a `check-all-green` job which will be set as a **required check** in branch protection rules for main.
This means that `check-all-green` will need to be successfull for a PR to pass checks.
Finally `Performance Benchmark` is set as a dependency of `check-all-green` so it has to be completed before `check-all-green` can run (perf benchmark can fail or be skipped, it is only important that it is completed).

