### PR TITLE
Bug: Fix vllm-tt in tt-forge wheel

### DIFF
--- a/.github/actions/set-release-facts/action.yaml
+++ b/.github/actions/set-release-facts/action.yaml
@@ -244,7 +244,7 @@ runs:
             fi
             artifact_name_prefix="xla-whl-release"
             artifact_download_glob='*{xla-whl-release,vllm-tt-whl-release,test-reports}*'
-            pip_wheel_names="pjrt-plugin-tt"
+            pip_wheel_names="pjrt-plugin-tt vllm-tt"
             test_perf="true"
             uplift_artifacts_by_commit="true"
         elif [[ "${{ inputs.repo }}" =~ "tt-forge" ]]; then

--- a/.github/scripts/template-setup.py
+++ b/.github/scripts/template-setup.py
@@ -9,7 +9,7 @@ setup(
     homepage="https://github.com/tenstorrent/tt-forge",
     install_requires=[
         "pjrt-plugin-tt @https://pypi.eng.aws.tenstorrent.com/pjrt-plugin-tt/pjrt_plugin_tt-${PJRT_PLUGIN_TT_TAG}-cp311-cp311-linux_x86_64.whl",
-        "vllm_tt @https://pypi.eng.aws.tenstorrent.com/vllm_tt/vllm_tt-${PJRT_PLUGIN_TT_TAG}-cp311-cp311-linux_x86_64.whl",
+        "vllm_tt @https://pypi.eng.aws.tenstorrent.com/vllm-tt/vllm_tt-${PJRT_PLUGIN_TT_TAG}-cp311-cp311-linux_x86_64.whl",
     ],
     python_requires=">=3.11",
     py_modules=[],


### PR DESCRIPTION
Fixes for https://github.com/tenstorrent/tt-forge/pull/648

Issue:

Had a typo in the `tt-forge` template setup.py 

```bash
7.082 ERROR: Could not install requirement vllm_tt@ https://pypi.eng.aws.tenstorrent.com/vllm_tt/vllm_tt-0.6.0.dev20251202-cp311-cp311-linux_x86_64.whl from https://pypi.eng.aws.tenstorrent.com/vllm_tt/vllm_tt-0.6.0.dev20251202-cp311-cp311-linux_x86_64.whl (from tt-forge==0.6.0.dev20251202) because of HTTP error 404 Client Error: Not Found for url: https://pypi.eng.aws.tenstorrent.com/vllm_tt/vllm_tt-0.6.0.dev20251202-cp311-cp311-linux_x86_64.whl for URL https://pypi.eng.aws.tenstorrent.com/vllm_tt/vllm_tt-0.6.0.dev20251202-cp311-cp311-linux_x86_64.whl
```
Run: https://github.com/tenstorrent/tt-forge/actions/runs/19846755229/job/56865650628#step:9:446

But did verify we do have https://pypi.eng.aws.tenstorrent.com/vllm-tt/ available 

Fixes:
- Fixed typo issue when `tt-forge` was pulling the `vllm-tt` wheel from our tt-pypi
- Fixed a doc issue on the `tt-xla` nightly to include instructions for downloading `vllm-tt` 


