### PR TITLE
Temporary device perf skip

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -14,7 +14,7 @@
       "libreq": "libgl1-mesa-glx libglib2.0-0",
       "skip-ttir-dump": false,
       "skip-ttnn-dump": false,
-      "skip-device-perf": false
+      "skip-device-perf": true
     },
     "tests": [
       {


### PR DESCRIPTION
On [latest nightly run](https://github.com/tenstorrent/tt-forge/actions/runs/19902649912) all models fail device perf.
We will disable it temporarily while we solve the problem so we can better track model status.