### PR TITLE
[TTNNPerfMetrics] Sum multiple graphs of model to benchmark report

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -10,7 +10,7 @@ import os
 import sys
 from typing import Dict, Any
 
-from utils import aggregate_ttnn_perf_metrics
+from utils import aggregate_ttnn_perf_metrics, sanitize_filename
 
 
 def load_module(module_path: str, module_name: str):
@@ -265,9 +265,10 @@ def main():
     config = read_args()
 
     # Standardize perf metrics filename: {project}_{model}_perf_metrics (backend adds .json)
-    project_prefix = config["project"].replace("-", "_")
-    model_prefix = config["model"].replace("-", "_")
-    config["ttnn_perf_metrics_output_file"] = f"{project_prefix}_{model_prefix}_perf_metrics"
+    # Sanitize project and model names for safe filesystem usage
+    sanitized_project = sanitize_filename(config["project"])
+    sanitized_model = sanitize_filename(config["model"])
+    config["ttnn_perf_metrics_output_file"] = f"{sanitized_project}_{sanitized_model}_perf_metrics"
 
     # Run the benchmark
     results = run_benchmark(config)

--- a/benchmark/tt-xla/llms.py
+++ b/benchmark/tt-xla/llms.py
@@ -6,6 +6,7 @@ import json
 import os
 from loguru import logger
 
+from benchmark.utils import sanitize_filename
 from llm_benchmark import benchmark_llm_torch_xla
 
 # Defaults for all llms
@@ -60,8 +61,8 @@ def test_llm(
         read_logits_fn: Function to extract logits from model output
     """
     model_loader = ModelLoaderModule(variant=variant)
-    # Sanitize variant name: replace / and - with _ to avoid directory paths, lowercase for consistency
-    sanitized_variant = str(variant).replace("/", "_").replace("-", "_").lower()
+    # Sanitize variant name for safe filesystem usage
+    sanitized_variant = sanitize_filename(str(variant))
     ttnn_perf_metrics_output_file = f"tt_xla_{sanitized_variant}_perf_metrics"
 
     print(f"Running LLM benchmark for variant: {variant}")

--- a/benchmark/tt-xla/vision_models.py
+++ b/benchmark/tt-xla/vision_models.py
@@ -3,8 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+import os
 
-from benchmark.utils import aggregate_ttnn_perf_metrics
+from benchmark.utils import aggregate_ttnn_perf_metrics, sanitize_filename
 from vision_benchmark import benchmark_vision_torch_xla
 
 # Defaults for all vision models
@@ -56,7 +57,9 @@ def test_vision(
     model_info_name = (
         model_loader.get_model_info(variant=variant).name if variant else model_loader.get_model_info().name
     )
-    ttnn_perf_metrics_output_file = f"tt_xla_{model_info_name.replace(' ', '_').replace('-', '_').lower()}_perf_metrics"
+    # Sanitize model name for safe filesystem usage
+    sanitized_model_name = sanitize_filename(model_info_name)
+    ttnn_perf_metrics_output_file = f"tt_xla_{sanitized_model_name}_perf_metrics"
 
     print(f"Running vision benchmark for model: {model_info_name}")
     print(

--- a/benchmark/utils.py
+++ b/benchmark/utils.py
@@ -4,6 +4,7 @@
 from typing import Any, Callable, Optional
 from loguru import logger
 import random
+import re
 import requests
 import time
 import os
@@ -303,6 +304,20 @@ def measure_cpu_fps(model, input, iterations=512):
         end = time.perf_counter()
         best_time = min(best_time, end - start)
     return 1 / best_time
+
+
+def sanitize_filename(name: str) -> str:
+    """
+    Sanitize a string to be safe for use in filenames.
+    Replaces illegal filesystem characters with underscores and converts to lowercase.
+    """
+    # Replace illegal filesystem characters: / \ : * ? " < > | and spaces
+    # Also replace dots and dashes for consistency
+    sanitized = re.sub(r'[/\\:*?"<>|\s.\-]', "_", str(name))
+    # Remove consecutive underscores
+    sanitized = re.sub(r"_+", "_", sanitized)
+    # Remove leading/trailing underscores and convert to lowercase
+    return sanitized.strip("_").lower()
 
 
 def aggregate_ttnn_perf_metrics(ttnn_perf_metrics_output_file, results):


### PR DESCRIPTION
### Ticket
[[TTNNPerfMetrics] Perf metrics overwritten when multiple graphs run (only last graph captured)](https://github.com/tenstorrent/tt-mlir/issues/6167)
Now they are saved in separate autonumerated files (ex. "name_0.json", "name_1.json",...) in XLA [[TTNNPerfMetrics] Autonumerate files for multiple graphs in a model #2468](https://github.com/tenstorrent/tt-xla/pull/2468).
Later collected and summed in TT-Forge for final report. 
* LLMs omit information from prefill, only use decode graph.