### PR TITLE
Update tt-xla resnet demo postprocessing

### DIFF
--- a/demos/tt-xla/cnn/resnet_demo.py
+++ b/demos/tt-xla/cnn/resnet_demo.py
@@ -50,7 +50,7 @@ def run_resnet_demo_case(variant):
 
     if not isinstance(output, (list, tuple)):
         output = [output]
-    loader.post_process(output)
+    loader.output_postprocess(co_out=output)
 
     print("=" * 60, flush=True)
 


### PR DESCRIPTION
The resnet demo is currently failing in demo tests since a change was made to the post processing function in tt-forge-models. Updating the post processing call to be `loader.output_postprocess(co_out=output)` fixes this issue.

Implementing the change suggested in https://github.com/tenstorrent/tt-forge/issues/685 (don't depend on tt-forge-models for demos) would help to avoid similar issues in the future.