### PR TITLE
For tt-forge-fe use wheel built in "On nightly" worfklow for release

### DIFF
--- a/.github/actions/set-release-facts/action.yaml
+++ b/.github/actions/set-release-facts/action.yaml
@@ -224,9 +224,6 @@ runs:
 
         if [[ "${{ inputs.repo }}" =~ "tt-forge-fe" ]]; then
             workflow="On nightly"
-            if [[ "${{ inputs.release_type }}" == "nightly" ]]; then
-                workflow="On push"
-            fi
             artifact_download_glob='*{wheel,test-reports}*'
             artifact_cleanup_file_glob='*{.json,benchmark_}*'
             workflow_result_in_job="fail-notify"


### PR DESCRIPTION
## Issue

Daily Releaser workflow is failing for tt-forge-fe, it cannot find "On push" job
https://github.com/tenstorrent/tt-forge/actions/runs/20220304229/job/58040956363

## Change

"On push" workflow is removed from tt-forge-fe, we will use wheel produced in "On nightly" for release.

Needs https://github.com/tenstorrent/tt-forge-fe/pull/3099