### PR TITLE
Set TORCH_HOME for persisting torch hub files

### DIFF
--- a/.github/workflows/call-perf-test.yml
+++ b/.github/workflows/call-perf-test.yml
@@ -156,6 +156,7 @@ jobs:
       env:
         HF_TOKEN: ${{ secrets.HF_TOKEN }}
         HF_HOME: /mnt/dockercache/huggingface
+        TORCH_HOME: /mnt/dockercache/torchhub
         HF_HUB_DISABLE_PROGRESS_BARS: 1
       run: |
         echo "Create perf report directory"


### PR DESCRIPTION
## Poblem

Downloads from torchub are not being cached and we started hitting rate limit during testing
This can be fixed by caching to predefined location, same as for Huggingface

## Issue
https://github.com/tenstorrent/tt-forge/issues/727