### PR TITLE
Enable device perf

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -14,7 +14,7 @@
       "libreq": "libgl1-mesa-glx libglib2.0-0",
       "skip-ttir-dump": false,
       "skip-ttnn-dump": false,
-      "skip-device-perf": true
+      "skip-device-perf": false
     },
     "tests": [
       {


### PR DESCRIPTION
We can enable device perf again.
Closes #718 

Run: https://github.com/tenstorrent/tt-forge/actions/runs/20309343679