### PR TITLE
Update Claude workflow permissions for full functionality

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,11 +19,11 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      actions: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -36,9 +36,9 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
-          # This is an optional setting that allows Claude to read CI results on PRs
+          # This setting allows Claude to read CI results and trigger workflows
           additional_permissions: |
-            actions: read
+            actions: write
 
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'


### PR DESCRIPTION
## Summary
- Update Claude GitHub Action permissions from read to write
- Enables Claude to trigger performance benchmark workflows
- Enables Claude to create pull requests and update issues

## Changes
- `contents: write` - for pushing branches and creating PRs
- `pull-requests: write` - for creating PRs
- `issues: write` - for updating issue comments  
- `actions: write` - for triggering workflows