### PR TITLE
Add 7B/8B LLM models to perf benchmark matrix

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -94,6 +94,11 @@
         "pytest": "benchmark/tt-xla/llms.py::test_llama_3_2_3b"
       },
       {
+        "name": "llama_3_1_8b_instruct",
+        "pyreq": "datasets loguru pytest pytorchcv requests tabulate timm tqdm transformers==4.52.4 torch==2.7.1",
+        "pytest": "benchmark/tt-xla/llms.py::test_llama_3_1_8b"
+      },
+      {
         "name": "microsoft_phi-1",
         "pyreq": "datasets loguru pytest pytorchcv requests tabulate timm tqdm transformers==4.52.4 torch==2.7.1",
         "pytest": "benchmark/tt-xla/llms.py::test_phi1"
@@ -124,6 +129,11 @@
         "pytest": "benchmark/tt-xla/llms.py::test_falcon3_3b"
       },
       {
+        "name": "tiiuae_falcon3-7b-base",
+        "pyreq": "datasets loguru pytest pytorchcv requests tabulate timm tqdm transformers==4.52.4 torch==2.7.1",
+        "pytest": "benchmark/tt-xla/llms.py::test_falcon3_7b"
+      },
+      {
         "name": "qwen_2_5_0_5b_instruct",
         "pyreq": "datasets loguru pytest pytorchcv requests tabulate timm tqdm transformers==4.52.4 torch==2.7.1",
         "pytest": "benchmark/tt-xla/llms.py::test_qwen_2_5_0_5b"
@@ -152,6 +162,26 @@
         "name": "qwen_3_4b",
         "pyreq": "datasets loguru pytest pytorchcv requests tabulate timm tqdm transformers==4.52.4 torch==2.7.1",
         "pytest": "benchmark/tt-xla/llms.py::test_qwen_3_4b"
+      },
+      {
+        "name": "qwen_3_8b",
+        "pyreq": "datasets loguru pytest pytorchcv requests tabulate timm tqdm transformers==4.52.4 torch==2.7.1",
+        "pytest": "benchmark/tt-xla/llms.py::test_qwen_3_8b"
+      },
+      {
+        "name": "qwen_2_5_7b_instruct",
+        "pyreq": "datasets loguru pytest pytorchcv requests tabulate timm tqdm transformers==4.52.4 torch==2.7.1",
+        "pytest": "benchmark/tt-xla/llms.py::test_qwen_2_5_7b"
+      },
+      {
+        "name": "mistral_7b",
+        "pyreq": "datasets loguru pytest pytorchcv requests tabulate timm tqdm transformers==4.52.4 torch==2.7.1",
+        "pytest": "benchmark/tt-xla/llms.py::test_mistral_7b"
+      },
+      {
+        "name": "ministral_8b",
+        "pyreq": "datasets loguru pytest pytorchcv requests tabulate timm tqdm transformers==4.52.4 torch==2.7.1",
+        "pytest": "benchmark/tt-xla/llms.py::test_ministral_8b"
       },
       {
         "name": "qwen_3_4b_embedding",

--- a/benchmark/tt-xla/llm_benchmark.py
+++ b/benchmark/tt-xla/llm_benchmark.py
@@ -83,12 +83,15 @@ def construct_inputs(
     input_prompt = DEFAULT_INPUT_PROMPT
     input_prompt = [input_prompt] * batch_size
 
+    # TODO: Only works on same length inputs for now
+    prompt_len = len(input_prompt[0])
+    assert all(len(prompt) == prompt_len for prompt in input_prompt), "All input prompts must have the same length"
+
     inputs = tokenizer(
         input_prompt,
         return_tensors="pt",
         max_length=max_cache_len,
         truncation=True,
-        padding=True,
     )
 
     # Static cache should be initialized on CPU and separately transferred to device

--- a/benchmark/tt-xla/llms.py
+++ b/benchmark/tt-xla/llms.py
@@ -258,7 +258,6 @@ def test_qwen_3_4b(output_file):
     from third_party.tt_forge_models.qwen_3.causal_lm.pytorch.loader import ModelLoader, ModelVariant
 
     variant = ModelVariant.QWEN_3_4B
-    # Disable BFP8 weight conversion due to OOM failure
     test_llm(ModelLoaderModule=ModelLoader, variant=variant, output_file=output_file)
 
 
@@ -276,7 +275,6 @@ def test_qwen_2_5_3b(output_file):
     test_llm(ModelLoaderModule=ModelLoader, variant=variant, output_file=output_file)
 
 
-# FAILED: Out of Memory: Not enough space to allocate 100663296 B DRAM buffer across 12 banks
 def test_qwen_3_8b(output_file):
     from third_party.tt_forge_models.qwen_3.causal_lm.pytorch.loader import ModelLoader, ModelVariant
 
@@ -284,7 +282,6 @@ def test_qwen_3_8b(output_file):
     test_llm(ModelLoaderModule=ModelLoader, variant=variant, output_file=output_file)
 
 
-# FAILED: Out of Memory: Not enough space to allocate 135790592 B DRAM buffer across 12 banks
 def test_qwen_2_5_7b(output_file):
     from third_party.tt_forge_models.qwen_2_5.causal_lm.pytorch.loader import ModelLoader, ModelVariant
 
@@ -324,7 +321,6 @@ def test_mamba_2_8b(output_file):
     test_llm(ModelLoaderModule=ModelLoader, variant=variant, output_file=output_file)
 
 
-# FAILED: ValueError: Asking to pad but the tokenizer does not have a padding token
 def test_falcon3_7b(output_file):
     from third_party.tt_forge_models.falcon.pytorch.loader import ModelLoader, ModelVariant
 
@@ -334,7 +330,6 @@ def test_falcon3_7b(output_file):
     test_llm(ModelLoaderModule=ModelLoader, variant=variant, output_file=output_file, read_logits_fn=read_logits_fn)
 
 
-# FAILED: ValueError: Asking to pad but the tokenizer does not have a padding token
 def test_mistral_7b(output_file):
     from third_party.tt_forge_models.mistral.pytorch.loader import ModelLoader, ModelVariant
 
@@ -342,7 +337,6 @@ def test_mistral_7b(output_file):
     test_llm(ModelLoaderModule=ModelLoader, variant=variant, output_file=output_file)
 
 
-# FAILED: ValueError: Asking to pad but the tokenizer does not have a padding token
 def test_ministral_8b(output_file):
     from third_party.tt_forge_models.mistral.pytorch.loader import ModelLoader, ModelVariant
 
@@ -350,7 +344,6 @@ def test_ministral_8b(output_file):
     test_llm(ModelLoaderModule=ModelLoader, variant=variant, output_file=output_file)
 
 
-# FAILED: Out of Memory: Not enough space to allocate 117440512 B DRAM buffer across 12 banks
 def test_llama_3_1_8b(output_file):
     from third_party.tt_forge_models.llama.causal_lm.pytorch.loader import ModelLoader, ModelVariant
 


### PR DESCRIPTION
Thanks to https://github.com/tenstorrent/tt-mlir/pull/6434 we can now run 7/8b models on n150 :)

## Summary
- Add larger LLM models (7B/8B) to the performance benchmark matrix
- Models added: llama_3_1_8b_instruct, falcon3-7b, qwen_3_8b, qwen_2_5_7b, mistral_7b, ministral_8b
- Remove outdated failure comments from llms.py
