### PR TITLE
Update Mistral 7B benchmark to use Instruct v0.3 variant

### DIFF
--- a/benchmark/tt-xla/llms.py
+++ b/benchmark/tt-xla/llms.py
@@ -333,7 +333,7 @@ def test_falcon3_7b(output_file):
 def test_mistral_7b(output_file):
     from third_party.tt_forge_models.mistral.pytorch.loader import ModelLoader, ModelVariant
 
-    variant = ModelVariant.MISTRAL_7B
+    variant = ModelVariant.MISTRAL_7B_INSTRUCT_V03
     test_llm(ModelLoaderModule=ModelLoader, variant=variant, output_file=output_file)
 
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
The `test_mistral_7b` benchmark was using the base `MISTRAL_7B` model variant. This updates it to use the instruction-tuned `MISTRAL_7B_INSTRUCT_V03` variant instead.

### What's changed
- Changed `test_mistral_7b` function in `benchmark/tt-xla/llms.py` to use `ModelVariant.MISTRAL_7B_INSTRUCT_V03` instead of `ModelVariant.MISTRAL_7B`
- The Instruct v0.3 variant uses the HuggingFace model `mistralai/Mistral-7B-Instruct-v0.3`

### Checklist
- [x] New/Existing tests provide coverage for changes