### PR TITLE
Enhance Claude GitHub Action with simple prompt, gh cli permissions, and manual trigger

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -47,7 +47,7 @@ jobs:
           additional_permissions: |
             actions: write
 
-          # Allow Claude to use gh cli for issues and PRs
+          # Allow Claude to use gh cli for issues, PRs, and CI
           allowed_tools: |
             Bash(gh issue create:*)
             Bash(gh issue view:*)
@@ -58,6 +58,10 @@ jobs:
             Bash(gh pr diff:*)
             Bash(gh pr view:*)
             Bash(gh pr list:*)
+            Bash(gh run list:*)
+            Bash(gh run view:*)
+            Bash(gh workflow list:*)
+            Bash(gh workflow view:*)
 
           # Use prompt from workflow_dispatch input when triggered manually
           prompt: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.prompt || '' }}


### PR DESCRIPTION
### Ticket
N/A

### Problem description
The Claude GitHub Action needed additional capabilities for better interaction with issues, PRs, and CI workflows.

### What's changed
- Enable `USE_SIMPLE_PROMPT` for simplified prompt mode
- Add `allowed_tools` for gh cli commands:
  - Issues: create, view, list
  - PRs: create, comment, diff, view, list
  - CI: run list/view, workflow list/view
  - Search
- Add `workflow_dispatch` trigger to allow manual runs from GitHub Actions UI with custom prompt input

### Checklist
- [ ] New/Existing tests provide coverage for changes