### PR TITLE
Fix mistral 7B tokenizer initialization in benchmarks

### DIFF
--- a/benchmark/tt-xla/requirements.txt
+++ b/benchmark/tt-xla/requirements.txt
@@ -5,6 +5,7 @@ loguru
 pytest
 pytorchcv
 requests
+sentencepiece
 tabulate
 timm
 torchvision==0.22.0


### PR DESCRIPTION
Mistral 7B benchmarks started hitting the error below in the last couple of days (observed when running benchmarks during tt-mlir uplift in tt-xla):

```
ValueError: Cannot instantiate this tokenizer from a slow version. If it's based on sentencepiece, make sure you have sentencepiece installed.
```

As proposed by the error message, I tried adding `sentencepiece` to the env locally, after which benchmarks started running successfully again. @odjuricicTT please review the PR, since I'm not sure if this is the tokenizer we want to use, or need to find a different solution.