### PR TITLE
Set cache location based on env

### DIFF
--- a/.github/workflows/call-perf-test.yml
+++ b/.github/workflows/call-perf-test.yml
@@ -82,7 +82,6 @@ jobs:
     env:
       # TODO: Revisit the addition of these env vars https://github.com/tenstorrent/tt-metal/issues/20161
       TRACY_NO_INVARIANT_CHECK: 1
-      DOCKER_CACHE_ROOT: /mnt/dockercache
 
     name: "${{ matrix.build.project }}-${{ matrix.build.name }} (${{ inputs.sh-runner && format('{0}-shared', matrix.build.runs-on) || (matrix.build.runs-on) }}, ${{ matrix.build.bs }}, ${{ matrix.build.lp }}) benchmark"
     steps:
@@ -93,6 +92,16 @@ jobs:
         fetch-depth: 1
         ref: ${{ inputs.ref || github.ref }}
         submodules: 'recursive'
+
+    - name: Set caching env variables
+      shell: bash
+      run: |
+        shared_runners=${{ inputs.sh-runner }}
+        if [[ "$shared_runners" == "" || "$shared_runners" == "false" ]]; then
+          echo "DOCKER_CACHE_ROOT=/mnt/dockercache" >> $GITHUB_ENV
+        else
+          echo "IRD_LF_CACHE=${{ vars.IRD_LF_CACHE }}" >> $GITHUB_ENV
+        fi
 
     - name: Fix HOME Directory
       shell: bash


### PR DESCRIPTION
### Problem
UFLD model loading failins on shared runners (CIv2) because cache location env var isn't properly set.

### Solution
Set DOCKER_CACHE_ROOT or IRD_LF_CACHE based on which environment the test is executed in (CIv1 or CIv2)


### Test
[Here](https://github.com/tenstorrent/tt-forge/actions/runs/20919469424) is a workflow ran on the latest commit on this branch which shows UFLD tests passing.