### PR TITLE
Fix: Update ResNet demo to use new output_postprocess signature

### DIFF
--- a/demos/tt-forge-fe/cnn/resnet_demo.py
+++ b/demos/tt-forge-fe/cnn/resnet_demo.py
@@ -29,16 +29,8 @@ def run_resnet_demo_case(variant):
     # Run inference on Tenstorrent device
     output = compiled_model(inputs)
 
-    # Post-process and display results
-    if variant == ModelVariant.RESNET_50_HF:
-        # Load tiny dataset
-        dataset = load_dataset("zh-plus/tiny-imagenet")
-        images = random.sample(dataset["valid"]["image"], 10)
-        loader.output_postprocess(
-            framework_model=model, compiled_model=compiled_model, inputs=images, dtype_override=torch.bfloat16
-        )
-    else:
-        loader.output_postprocess(output)
+    # Post-process
+    loader.output_postprocess(output)
 
     print("=" * 60, flush=True)
 


### PR DESCRIPTION
## Summary

This PR fixes the ResNet demo test case by updating the call to `output_postprocess()` to match the refactored method signature that only accepts the compiled model output.

## Problem

The ResNet demo test case for `RESNET_50_HF` variant was failing in the CI pipeline(i.e https://github.com/tenstorrent/tt-forge/actions/runs/20908146782/job/60065697953) with the following error:


```
TypeError: ModelLoader.output_postprocess() got an unexpected keyword argument 'framework_model'
```

**Error Trace:**
```
File "/__w/tt-forge/tt-forge/demos/tt-forge-fe/cnn/resnet_demo.py", line 37, in run_resnet_demo_case
    loader.output_postprocess(
TypeError: ModelLoader.output_postprocess() got an unexpected keyword argument 'framework_model'
```

**Root Cause:**
The `output_postprocess()` method in the ResNet model loader was refactored to simplify its signature. The previous version accepted multiple legacy parameters (`framework_model`, `compiled_model`, `inputs`, `dtype_override`, etc.), but the current implementation only accepts `output` (the compiled model output tensor) and an optional `top_k` parameter. The demo code was still using the old calling convention, passing `framework_model`, `compiled_model`, and `inputs` as keyword arguments, which caused the TypeError.

## Solution

Updated the ResNet demo to pass only the compiled model output to `output_postprocess()`, matching the new simplified method signature. The fix changes the call from:

```python
loader.output_postprocess(
    framework_model=model, compiled_model=compiled_model, inputs=images, dtype_override=torch.bfloat16
)
```

to:

```python
loader.output_postprocess(output)
```

This aligns with the current method signature that expects only the model output tensor.
