### PR TITLE
Add TP benchmarks for qwen 32B and mistral 24B models

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -207,12 +207,6 @@
         "runs-on": "llmbox"
       },
       {
-        "name": "llama_3_70b_tp",
-        "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
-        "pytest": "benchmark/tt-xla/llms.py::test_llama_3_70b_tp",
-        "runs-on": "llmbox"
-      },
-      {
         "name": "microsoft_phi-1",
         "pyreq": "datasets loguru pytest requests torch==2.9.0 tqdm transformers==4.57.1",
         "pytest": "benchmark/tt-xla/test_llms.py::test_phi1"

--- a/benchmark/tt-xla/test_llms.py
+++ b/benchmark/tt-xla/test_llms.py
@@ -592,11 +592,3 @@ def test_llama_3_1_70b_tp(output_file, num_layers, request):
         request=request,
         required_pcc=-1.0,
     )  # https://github.com/tenstorrent/tt-xla/issues/2976
-
-    
-def test_llama_3_70b_tp(output_file, num_layers, request):
-    from third_party.tt_forge_models.llama.causal_lm.pytorch.loader import ModelLoader, ModelVariant
-
-    variant = ModelVariant.LLAMA_3_70B
-    test_llm_tp(ModelLoader, variant, output_file, num_layers=num_layers, request=request)
-    


### PR DESCRIPTION
Add the following 4 models to TP benchmarks.

```
mistral/pytorch-mistral_small_24b_instruct_2501
qwen_2_5/causal_lm/pytorch-32b_instruct
qwen_2_5_coder/pytorch-32b_instruct
qwen_3/causal_lm/pytorch-32b
```