### PR TITLE
Fix device perf

### DIFF
--- a/.github/workflows/call-perf-test.yml
+++ b/.github/workflows/call-perf-test.yml
@@ -317,6 +317,7 @@ jobs:
         apt-get install -y -qq --no-install-recommends libtbb12 libcapstone4
         pip install ttrt-whl-tracy/ttrt*.whl --upgrade
         pip install torch==2.3.0 --index-url https://download.pytorch.org/whl/cpu
+        pip install pandas==2.3.3
 
     - name: Run Device Perf
       if: ${{ !matrix.build.skip-device-perf && !inputs.skip-device-perf && matrix.build.runs-on != 'p150' && matrix.build.runs-on != 'llmbox' }}


### PR DESCRIPTION
### Problem description

On [latest nightly](https://github.com/tenstorrent/tt-forge/actions/runs/21236267881) all models failed because of Run device perf job error.
It was caused by pandas version change 2.3.3 -> 3.0.0.

### What's changed
Set pandas==2.3.3 when installing ttrt wheel.