### PR TITLE
GPT2 fix for release

### DIFF
--- a/demos/tt-xla/nlp/jax/gpt_demo.py
+++ b/demos/tt-xla/nlp/jax/gpt_demo.py
@@ -32,7 +32,7 @@ def run_gpt2_demo_case(variant):
 
     def generate_logits(input_ids, params):
         model_ = nnx.merge(graphdef, params)
-        outputs = model_(input_ids)
+        outputs = model_(**input_ids)
         return outputs.logits
 
     # Compile the model using JAX JIT


### PR DESCRIPTION
Due to change in the GPT2 structure in `tt-forge-models`, we needed to unpack the input ids, which are now a dictionary.