### PR TITLE
Omit parameters from perf regression check query

### DIFF
--- a/.github/workflows/test-superset-api.yml
+++ b/.github/workflows/test-superset-api.yml
@@ -22,48 +22,12 @@ jobs:
       - name: Checkout code # only needed when using action in same repo
         uses: actions/checkout@v3
 
-      # - name: Call Superset API
-      #   id: api-call
-      #   uses: ./.github/actions/superset-api
-      #   with:
-      #     query: 'benchmarks/last_measurement'
-      #     query_params: '{"project":"tenstorrent/tt-metal","ml_model_name":"tiiuae/falcon-7b-instruct","batch_size":"32","precision":"prefill[BFLOAT16-DRAM]_decode[BFLOAT16-L1_SHARDED]"}'
-
-
-      - name: Testing
-        shell: bash
-        run: |
-          workflow_id=$(curl -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            -H "Accept: application/vnd.github.v3+json" \
-            "https://api.github.com/repos/tenstorrent/tt-forge/actions/workflows/perf-benchmark.yml/runs?status=completed&branch=main&per_page=100&actor=github-actions\[bot\]" \
-            | jq -r '.workflow_runs[] | select(.name | contains("draft") | not) | .id' | head -1)
-
-          workflow_id_2=$(curl -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            -H "Accept: application/vnd.github.v3+json" \
-            "https://api.github.com/repos/tenstorrent/tt-forge/actions/workflows/perf-benchmark.yml/runs?status=completed&branch=main&per_page=100&actor=github-actions\[bot\]" \
-            | jq -r '.workflow_runs[] | select(.name | (contains("draft") | not) and contains("parent_run_id")) | .id' | head -1)
-
-          echo "without parent_run_id filter: $workflow_id"
-          echo "with parent_run_id filter: $workflow_id_2"
-
-      - name: Call Superset API
-        id: api-call-2
-        uses: ./.github/actions/superset-api
-        with:
-          query: 'benchmarks/last_measurement'
-          query_params: '{"project":"tt-forge/tt-xla","ml_model_name":"pytorch_bge_m3_encode_base_nlp_embed_gen_custom","github_pipeline_id":"21577945488","arch":"wormhole","batch_size":"12","precision":"bfloat16"}'
-
-      - name: Display Response
-        run: |
-          echo "API Response:"
-          echo '${{ steps.api-call-2.outputs.response }}'
-
       - name: Call Superset API
         id: api-call
         uses: ./.github/actions/superset-api
         with:
           query: 'benchmarks/last_measurement'
-          query_params: '{"project":"tt-forge/tt-xla","ml_model_name":"pytorch_bge_m3_encode_base_nlp_embed_gen_custom","github_pipeline_id":"21577945488","arch":"wormhole"}'
+          query_params: '{"project":"tenstorrent/tt-metal","ml_model_name":"tiiuae/falcon-7b-instruct","batch_size":"32","precision":"prefill[BFLOAT16-DRAM]_decode[BFLOAT16-L1_SHARDED]"}'
 
       - name: Display Response
         run: |


### PR DESCRIPTION
### Problem
Perf regression check was using `batch_size` and `precision` to filter out the results it fetches from the db.
This was problematic because we have multiple sources of truth for those parameters across our codebase.

### Solution
Omit `batch_size` and `precision` from the db queries for previous perf run results.