### PR TITLE
Add device_count, mesh_shape, and device_type to benchmark metrics

### DIFF
--- a/benchmark/tt-xla/encoder_benchmark.py
+++ b/benchmark/tt-xla/encoder_benchmark.py
@@ -306,6 +306,7 @@ def benchmark_encoder_torch_xla(
         input_is_image=False,
         input_sequence_length=input_sequence_length,
         enable_weight_bfp8_conversion=enable_weight_bfp8_conversion,
+        device_count=xr.global_runtime_device_count(),
     )
 
     return result

--- a/benchmark/tt-xla/llm_benchmark.py
+++ b/benchmark/tt-xla/llm_benchmark.py
@@ -495,6 +495,10 @@ def benchmark_llm_torch_xla(
     pcc_value = compute_pcc(output_logits[0][0], cpu_logits[0], required_pcc=required_pcc)
     print(f"PCC verification passed with PCC={pcc_value:.6f}")
 
+    # Get device count and mesh info for metrics
+    device_count = xr.global_runtime_device_count()
+    mesh_shape = tuple(mesh.shape()) if mesh is not None else None
+
     result = create_benchmark_result(
         full_model_name=full_model_name,
         model_type=model_type,
@@ -520,6 +524,8 @@ def benchmark_llm_torch_xla(
         arch=arch or get_xla_device_arch(),
         input_is_image=False,
         input_sequence_length=input_sequence_length,
+        device_count=device_count,
+        mesh_shape=mesh_shape,
     )
 
     return result

--- a/benchmark/tt-xla/resnet_jax_benchmark.py
+++ b/benchmark/tt-xla/resnet_jax_benchmark.py
@@ -218,6 +218,7 @@ def benchmark_resnet_jax(
         torch_xla_enabled=False,
         device_name=socket.gethostname(),
         arch=get_jax_device_arch(),
+        device_count=len(jax.devices("tt")),
     )
 
     return result

--- a/benchmark/tt-xla/utils.py
+++ b/benchmark/tt-xla/utils.py
@@ -103,6 +103,27 @@ def get_benchmark_metadata() -> Dict[str, str]:
     }
 
 
+def get_device_type(arch: str, device_count: int) -> str:
+    """Determine device type string based on architecture and device count."""
+
+    if device_count == 32:
+        return "galaxy"
+    if device_count == 8:
+        return "llmbox"
+    if arch == "wormhole":
+        if device_count == 1:
+            return "n150"
+        if device_count == 2:
+            return "n300"
+    if arch == "blackhole":
+        if device_count == 1:
+            return "p150"
+        if device_count == 2:
+            return "p300"
+
+    return "unknown"
+
+
 def sanitize_model_name(value: Any) -> str:
     text = str(value).strip()
     text = re.sub(r"\s+", "_", text)
@@ -285,9 +306,10 @@ def create_benchmark_result(
     device_name: str = "",
     galaxy: bool = False,
     arch: str = "",
-    chips: int = 1,
     input_is_image: bool = True,
     input_sequence_length: Optional[int] = -1,
+    device_count: int = 1,
+    mesh_shape: Optional[tuple] = None,
 ) -> Dict[str, Any]:
     """Create a standardized benchmark result dictionary.
 
@@ -368,7 +390,9 @@ def create_benchmark_result(
             "device_name": device_name,
             "galaxy": galaxy,
             "arch": arch,
-            "chips": chips,
+            "device_count": device_count,
+            "mesh_shape": mesh_shape,
+            "device_type": get_device_type(arch, device_count),
         },
     }
 

--- a/benchmark/tt-xla/vision_benchmark.py
+++ b/benchmark/tt-xla/vision_benchmark.py
@@ -256,6 +256,7 @@ def benchmark_vision_torch_xla(
         backend="tt",
         device_name=socket.gethostname(),
         arch=get_xla_device_arch(),
+        device_count=xr.global_runtime_device_count(),
     )
 
     return result

--- a/benchmark/utils.py
+++ b/benchmark/utils.py
@@ -15,8 +15,6 @@ from filelock import FileLock
 from tqdm import tqdm
 import numpy as np
 import torch
-from transformers import AutoImageProcessor
-from datasets import load_dataset
 
 try:
     import paddle
@@ -199,6 +197,9 @@ def load_dataset_classification(model_version, dataset_name, split, batch_size, 
     labels: list
         The labels for the input data.
     """
+
+    from transformers import AutoImageProcessor
+    from datasets import load_dataset
 
     image_processor = AutoImageProcessor.from_pretrained(model_version)
     # Load the dataset as a generator


### PR DESCRIPTION
### Problem
Benchmark metrics sent to Superset are missing parallelization and device type information needed for performance analysis across different hardware configurations. Issue #835

### Solution
Extend the `device_info` dictionary in benchmark results with:
- `device_count`: Number of devices from `xr.global_runtime_device_count()`
- `mesh_shape`: Multi-chip mesh configuration tuple (e.g., `(2, 2)`)
- `device_type`: Derived from architecture and device count:
  - `n150`/`p150` for 1 device (wormhole/blackhole)
  - `n300` for 2 devices
  - `llmbox` for 8 devices
  - `galaxy` for 32 devices

### Changes
- Added `get_device_type()` helper function in `utils.py`
- Updated `create_benchmark_result()` to accept new parameters
- Updated all benchmark files to pass device info

### Testing
- Tested locally with mnist benchmark - passed

Closes #835