### PR TITLE
Execute tt-forge-install for tt-forge wheel as well

### DIFF
--- a/.github/Dockerfile.single-wheel-slim
+++ b/.github/Dockerfile.single-wheel-slim
@@ -17,7 +17,7 @@ RUN --mount=type=bind,source=$WHEEL_FILES_PATH,target=/wheels \
     eval "$(pyenv init -)" && \
     for wheel in /wheels/*.whl; do \
       pip install "$wheel"; \
-      if [[ "$wheel" == *"pjrt_"* ]]; then \
+      if [[ "$wheel" == "tt_pjrt_"* || "$wheel" == "tt_forge-"* ]]; then \
         tt-forge-install; \
       fi; \
     done && \


### PR DESCRIPTION
### Problem
Sfpi is no longer packaged into the tt-xla wheel, this means it has to be installed using the `tt-forge-install` tool.
Logic for doing this was added for when tt-xla wheel is getting installed, but not for when tt-forge is. 
(tt-forge whell is just a wrapper around the tt-xla wheel, functionally they are the same)

### Solution
Expand the logic to run `tt-forge-install` when "tt_forge-"* wheel is getting installed as well.
Change \*"pjrt_"\* condition to "pjrt_"* because the string we are looking for is always at the start of the wheel name.