### PR TITLE
Match string anywhere in filename

### DIFF
--- a/.github/Dockerfile.single-wheel-slim
+++ b/.github/Dockerfile.single-wheel-slim
@@ -17,7 +17,7 @@ RUN --mount=type=bind,source=$WHEEL_FILES_PATH,target=/wheels \
     eval "$(pyenv init -)" && \
     for wheel in /wheels/*.whl; do \
       pip install "$wheel"; \
-      if [[ "$wheel" == "tt_pjrt_"* || "$wheel" == "tt_forge-"* ]]; then \
+      if [[ "$wheel" == *"tt_pjrt_"* || "$wheel" == *"tt_forge-"* ]]; then \
         tt-forge-install; \
       fi; \
     done && \


### PR DESCRIPTION
### Problem
Typo in matching wheel file names, name is actually a path to the wheel so match if anywhere in string.

### Solution
Match if string anywhere in wheel filename.