### PR TITLE
Install sfip after installing custom xla wheel

### DIFF
--- a/.github/actions/install-wheel/action.yml
+++ b/.github/actions/install-wheel/action.yml
@@ -91,6 +91,6 @@ runs:
           cd $(ls | grep -E "${{ steps.set-wheel-name.outputs.artifact }}")
         fi
         pip install ${{ steps.set-wheel-name.outputs.wheel_name }} --upgrade
-        if [[ "$wheel" == *"pjrt_"* ]]; then
+        if [[ "${{ steps.set-wheel-name.outputs.wheel_name }}" == *"pjrt_"* ]]; then
           tt-forge-install;
         fi;


### PR DESCRIPTION
### Problem
TT-xla wheel no longer has sfpi packaged inside of it.
When dispatching perf benchmark from tt-xla, we are using the [Dockerfile.ubuntu-22-04-py3-11](https://github.com/tenstorrent/tt-forge/blob/main/.github/Dockerfile.ubuntu-22-04-py3-11) as a docker image and installing the tt-xla wheel inside of it.
Neither the docker image nor the wheel have sfpi preinstalled.

### Solution
Added a step after the tt-xla wheel is installed in this context to execute tt-forge-install.