### PR TITLE
Fix ld.lld-17 Issue in tt-forge-onnx demos 

### DIFF
--- a/.github/workflows/demo-tests.yml
+++ b/.github/workflows/demo-tests.yml
@@ -111,6 +111,31 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
           submodules: 'recursive'
 
+      - name: Install dependencies
+        if: matrix.project == 'tt-forge-onnx'
+        shell: bash
+        run: |
+          if command -v ld.lld-17 &> /dev/null; then
+            echo "ld.lld-17 is already available"
+            ld.lld-17 --version
+          else
+            echo "ld.lld-17 not found, installing lld-17..."
+
+            wget -qO /tmp/llvm.sh https://apt.llvm.org/llvm.sh && \
+            chmod +x /tmp/llvm.sh && \
+            /tmp/llvm.sh 17 >/dev/null 2>&1 || true
+
+            apt-get update -qq && apt-get install -y -qq lld-17 >/dev/null 2>&1
+
+            if command -v ld.lld-17 &> /dev/null || [ -x /usr/bin/ld.lld-17 ]; then
+              echo "Successfully installed ld.lld-17"
+              ld.lld-17 --version || /usr/bin/ld.lld-17 --version
+            else
+              echo "ERROR: Failed to install ld.lld-17"
+              exit 1
+            fi
+          fi
+
       - name: Run ${{ matrix.project }} demo ${{ matrix.name }}
         shell: bash
         run: |


### PR DESCRIPTION
## Problem

The `tt-forge-onnx` demos were failing with linker errors when running certain models (resnet, mobilenetv2, bert):

```
Running linker command:
ld.lld-17 -o /tmp/ttmlir_tmp-716a38/llvm-dylib-module-ad74ed.so -nostdlib -static -shared --strip-debug /tmp/ttmlir_tmp-716a38/llvm-dylib-module-a79932.o
sh: 1: ld.lld-17: not found
Linking failed; escaped command line returned exit code 32512
```

## Root Cause

This issue was introduced by CPU-hoisted const-eval being enabled by default in the tt-mlir uplift (see [tt-forge-onnx PR #3167](https://github.com/tenstorrent/tt-forge-onnx/pull/3167)). When models trigger CPU-hoisted const-eval (for example, ResNet, MobileNetV2, or BERT), the compiler generates a dynamic library from the CPU module. This process requires `ld.lld-17` for linking, which is **hardcoded in `LLVMToDynamicLib.cpp`**.

However, the Docker image used in the `tt-forge` demo-tests workflow (`tt-forge-slim`) does **not** contain `ld.lld-17`, which leads to the linker failure shown above.

## Solution

Added a workflow step in `demo-tests.yml` to check `ld.lld-17` is available  if not install it before running demos, but **only for the `tt-forge-onnx` project**. Triggered the `demo-tests.yml`  workflow, all tests passed without any linker errors.

Reference: https://github.com/tenstorrent/tt-forge/pull/877
CI pipeline: https://github.com/tenstorrent/tt-forge/actions/runs/21752428115




