### PR TITLE
Disable fp32 dest acc on failing models

### DIFF
--- a/benchmark/tt-xla/llm_benchmark.py
+++ b/benchmark/tt-xla/llm_benchmark.py
@@ -269,6 +269,7 @@ def benchmark_llm_torch_xla(
     shard_spec_fn,
     arch,
     required_pcc,
+    fp32_dest_acc_en=None,
 ):
     """
     Benchmark an LLM (Large Language Model) using PyTorch and torch-xla.
@@ -408,6 +409,8 @@ def benchmark_llm_torch_xla(
         "experimental_enable_weight_bfp8_conversion": enable_weight_bfp8_conversion,
         "experimental_enable_permute_matmul_fusion": experimental_enable_permute_matmul_fusion,
     }
+    if fp32_dest_acc_en is not None:
+        options["fp32_dest_acc_en"] = fp32_dest_acc_en
 
     torch_xla.set_custom_compile_options(options)
 

--- a/benchmark/tt-xla/test_llms.py
+++ b/benchmark/tt-xla/test_llms.py
@@ -53,6 +53,7 @@ def test_llm(
     shard_spec_fn=None,
     arch=None,
     required_pcc=DEFAULT_REQUIRED_PCC,
+    fp32_dest_acc_en=None,
     num_layers=None,
     request=None,
 ):
@@ -120,6 +121,7 @@ def test_llm(
         shard_spec_fn=shard_spec_fn,
         arch=arch,
         required_pcc=required_pcc,
+        fp32_dest_acc_en=fp32_dest_acc_en,
     )
 
     if output_file:
@@ -441,7 +443,12 @@ def test_ministral_8b(output_file, num_layers, request):
 
     variant = ModelVariant.MINISTRAL_8B
     test_llm(
-        ModelLoaderModule=ModelLoader, variant=variant, output_file=output_file, num_layers=num_layers, request=request
+        ModelLoaderModule=ModelLoader,
+        variant=variant,
+        output_file=output_file,
+        num_layers=num_layers,
+        request=request,
+        fp32_dest_acc_en=False,
     )
 
 
@@ -450,7 +457,12 @@ def test_llama_3_1_8b(output_file, num_layers, request):
 
     variant = ModelVariant.LLAMA_3_1_8B_INSTRUCT
     test_llm(
-        ModelLoaderModule=ModelLoader, variant=variant, output_file=output_file, num_layers=num_layers, request=request
+        ModelLoaderModule=ModelLoader,
+        variant=variant,
+        output_file=output_file,
+        num_layers=num_layers,
+        request=request,
+        fp32_dest_acc_en=False,
     )
 
 


### PR DESCRIPTION
Llama 8b and ministral 8b are currently failing due to [this issue](https://github.com/tenstorrent/tt-mlir/issues/6920). This happens only when `fp32_dest_acc` is enabled, which is by default.

Setting `fp32_dest_acc_en=false` for these models until we resolve this.

[Perf Benchmark
](https://github.com/tenstorrent/tt-forge/actions/runs/21755316248)