### PR TITLE
Limit produce data trigger only on tt-forge

### DIFF
--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -304,7 +304,7 @@ jobs:
   produce-data:
     needs:
       - fail-send-msg
-    if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+    if: ${{ always() && inputs.parent_run_id != '' }}
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository
@@ -314,11 +314,6 @@ jobs:
           fetch-depth: 1
           ref: ${{ inputs.ref || github.ref }}
           submodules: 'recursive'
-
-      - name: Logging
-        shell: bash
-        run: |
-          echo "${{ github.event_name }}"
 
       - name: Trigger produce_data.yml
         uses: ./.github/actions/trigger-workflow


### PR DESCRIPTION
### Problem
Produce-data job was made as a workaround for triggereing collect data workflows in tt-forge.
It is causing errors when perf benchmark is triggered from tt-xla.

### Solution
Produce data job is not needed when perf benchmark is triggered from tt-xla because the collect data workflow can catch it on it's on (name is Performance Benchmark so collect data workflow can recognize it).
Only trigger the job when perf benchmark is triggered as a workflow call (because when it's triggered as a workflow call it has the exact name "Performance Benchmark" and collect data workflow can match it).