### PR TITLE
Run collect data when demo tests dispatched by nightly

### DIFF
--- a/.github/workflows/demo-tests.yml
+++ b/.github/workflows/demo-tests.yml
@@ -184,11 +184,17 @@ jobs:
   produce-data:
     needs:
       - fail-send-msg
-    if: always()
+    if: ${{ always() && inputs.parent_run_id != '' }}
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository
         uses: actions/checkout@v4
+        with:
+          repository: 'tenstorrent/tt-forge'
+          fetch-depth: 1
+          ref: ${{ inputs.ref || github.ref }}
+          submodules: 'recursive'
+
       - name: Trigger produce_data.yml
         uses: ./.github/actions/trigger-workflow
         env:


### PR DESCRIPTION
### Problem
Don't trigger produce data job in demo tests if they were triggered by the nightly release process.
Similar to what was already done for perf tests in #879.

### Solution
Use the filter to check if produce data should be triggered.