### PR TITLE
Stop daily releases for tt-xla and tt-forge

### DIFF
--- a/.github/actions/set-release-facts/action.yaml
+++ b/.github/actions/set-release-facts/action.yaml
@@ -154,7 +154,7 @@ runs:
         # Full repository name with "tenstorrent/" prefix
         repo_full="tenstorrent/${repo_short}"
         # List of all repos that will release nightly on a schedule
-        schedule_nightly_repos='tenstorrent/tt-forge-onnx tenstorrent/tt-mlir tenstorrent/tt-forge tenstorrent/tt-xla'
+        schedule_nightly_repos='tenstorrent/tt-forge-onnx tenstorrent/tt-mlir'
         # List of repos that are allowed to update RC and Stable releases on a schedule
         schedule_rc_stable_update_repos='tenstorrent/tt-forge-onnx tenstorrent/tt-xla tenstorrent/tt-forge'
         # Allow workflow failures when finding build workflows


### PR DESCRIPTION
### Problem
TT-xla and tt-forge daily releases are moving to tt-xla ([PR](https://github.com/tenstorrent/tt-xla/pull/3225)), tt-forge shouldn't release them anymore.

### Solution
Stop daily releases of tt-xla and tt-forge from tt-forge repo.