### PR TITLE
Add resnet onnx demos and fix paddlepaddle demos and ci

### DIFF
--- a/.github/workflows/demo-tests.yml
+++ b/.github/workflows/demo-tests.yml
@@ -113,13 +113,17 @@ jobs:
 
       - name: Run ${{ matrix.project }} demo ${{ matrix.name }}
         shell: bash
+        env:
+          DOWNLOAD_RETRY_LIMIT: 10
         run: |
           demo_file=$(basename "${{ matrix.path }}")
           demo_folder=$(dirname demos/${{ matrix.project }}/${{ matrix.path }})
 
           export PYTHONPATH=$(pwd) # Add repository root to PYTHONPATH so demos can find models in third_party folder
           cd $demo_folder
-          pip install -r requirements.txt
+          if [ -f requirements.txt ]; then
+            pip install -r requirements.txt
+          fi
           python $demo_file
 
   fail-notify:

--- a/.github/workflows/models-matrix.json
+++ b/.github/workflows/models-matrix.json
@@ -5,10 +5,7 @@
       "runs-on": ["n150", "p150"]
     },
     "tests": [
-      { "name": "mobile_netv2", "path": "cnn/mobile_netv2_demo.py" },
-      { "name": "resnet",       "path": "cnn/resnet_demo.py" },
-      { "name": "resnet_onnx",  "path": "cnn/resnet_onnx_demo.py" },
-      { "name": "bert",         "path": "nlp/bert_demo.py" }
+      { "name": "resnet50_onnx", "path": "onnx/cnn/resnet_demo.py" }
     ]
   },
   {

--- a/demos/tt-forge-onnx/README.md
+++ b/demos/tt-forge-onnx/README.md
@@ -4,39 +4,35 @@ This directory contains example implementations of popular deep learning models 
 
 >**NOTE:** TT-Forge-ONNX does not support multi-chip configurations; it is for single-chip projects only.
 
+## Directory Structure
+
+The demos are organized by framework and model type:
+
+- **`onnx/`** - Demos that convert PyTorch models to ONNX format
+  - `cnn/` - Computer vision models (ResNet, etc.)
+
+- **`paddlepaddle/`** - Demos using PaddlePaddle models
+  - `cnn/` - Computer vision models (ResNet, AlexNet, DenseNet, GoogLeNet, MobileNetV2)
+  - `multimodal/` - Multimodal models (BLIP)
+
 ## Available Demos
+
+### ONNX Demos (PyTorch → ONNX)
 
 | Model                    | Model Type | Description                                                             | Demo Code                                              |
 |--------------------------|------------|-------------------------------------------------------------------------|--------------------------------------------------------|
-| AlexNet                  | CNN        | Classic deep CNN architecture for image classification                  | [`cnn/alexnet_demo.py`](cnn/alexnet_demo.py)           |
-| AutoEncoder (Linear)     | CNN        | Simple linear autoencoder for image reconstruction                      | [`cnn/autoencoder_linear.py`](cnn/autoencoder_linear.py) |
-| DeiT                     | CNN        | Data-efficient Image Transformer for image classification               | [`cnn/deit_demo.py`](cnn/deit_demo.py)                 |
-| DenseNet                 | CNN        | Densely connected convolutional network for image classification        | [`cnn/densenet_demo.py`](cnn/densenet_demo.py)         |
-| DLA                      | CNN        | Deep Layer Aggregation for image classification                         | [`cnn/dla_demo.py`](cnn/dla_demo.py)                   |
-| EfficientNet             | CNN        | Scalable and efficient CNN model for image classification               | [`cnn/efficientnet_demo.py`](cnn/efficientnet_demo.py) |
-| GhostNet                 | CNN        | Lightweight CNN using ghost modules for image classification            | [`cnn/ghostnet_demo.py`](cnn/ghostnet_demo.py)         |
-| HRNet                    | CNN        | High-Resolution Network for image classification                        | [`cnn/hrnet_demo.py`](cnn/hrnet_demo.py)               |
-| MNIST                    | CNN        | CNN for handwritten digit classification                                | [`cnn/mnist_demo.py`](cnn/mnist_demo.py)               |
-| MobileNetV1              | CNN        | Efficient CNN for mobile vision applications                            | [`cnn/mobile_netv1_demo.py`](cnn/mobile_netv1_demo.py) |
-| MobileNetV2              | CNN        | Lightweight CNN for MNIST digit classification                          | [`cnn/mobile_netv2_demo.py`](cnn/mobile_netv2_demo.py) |
-| MonoDepth2               | CNN        | Monocular depth estimation model                                        | [`cnn/monodepth2_demo.py`](cnn/monodepth2_demo.py)     |
-| RegNet                   | CNN        | Self-Regulated Network for image classification                         | [`cnn/regnet_demo.py`](cnn/regnet_demo.py)             |
-| ResNet-50                | CNN        | Deep residual network for image classification                          | [`cnn/resnet_50_demo.py`](cnn/resnet_50_demo.py)       |
-| ResNet-50 (ONNX)         | CNN        | ResNet-50 model using ONNX format                                       | [`cnn/resnet_onnx_demo.py`](cnn/resnet_onnx_demo.py)   |
-| ResNeXt                  | CNN        | Aggregated residual transformation model for image classification       | [`cnn/resnext_demo.py`](cnn/resnext_demo.py)           |
-| SegFormer                | CNN        | Transformer-based efficient image classifier                            | [`cnn/segformer_demo.py`](cnn/segformer_demo.py)       |
-| Swin Transformer         | CNN        | Hierarchical vision transformer for image classification                | [`cnn/swin_demo.py`](cnn/swin_demo.py)                 |
-| VGG                      | CNN        | Classic CNN with deep convolutional layers                              | [`cnn/vgg_demo.py`](cnn/vgg_demo.py)                   |
-| ViT                      | CNN        | Vision Transformer for image classification                             | [`cnn/vit_demo.py`](cnn/vit_demo.py)                   |
-| WideResNet               | CNN        | Wider variant of ResNet for image classification                        | [`cnn/wideresnet_demo.py`](cnn/wideresnet_demo.py)     |
-| Xception                 | CNN        | Depthwise separable CNN for image classification                        | [`cnn/xception_demo.py`](cnn/xception_demo.py)         |
-| BERT                     | NLP        | Transformer-based model for language understanding                      | [`nlp/bert_demo.py`](nlp/bert_demo.py)                 |
-| Bloom                    | NLP        | Causal language model for text generation                               | [`nlp/bloom_demo.py`](nlp/bloom_demo.py)               |
-| DistilBERT               | NLP        | Lightweight version of BERT for masked language modeling                | [`nlp/distilbert_demo.py`](nlp/distilbert_demo.py)     |
-| Falcon                   | NLP        | Causal language model for code/text generation                          | [`nlp/falcon_demo.py`](nlp/falcon_demo.py)             |
-| GPT-Neo                  | NLP        | GPT-style autoregressive transformer                                    | [`nlp/gptneo_demo.py`](nlp/gptneo_demo.py)             |
-| RoBERTa                  | NLP        | Robust BERT variant for sentiment analysis                              | [`nlp/roberta_demo.py`](nlp/roberta_demo.py)           |
-| SqueezeBERT              | NLP        | Lightweight transformer for text classification                         | [`nlp/squeezebert_demo.py`](nlp/squeezebert_demo.py)   |
+| ResNet                   | CNN        | Deep residual network for image classification (converted to ONNX)      | [`onnx/cnn/resnet_demo.py`](onnx/cnn/resnet_demo.py)   |
+
+### PaddlePaddle Demos
+
+| Model                    | Model Type | Description                                                             | Demo Code                                              |
+|--------------------------|------------|-------------------------------------------------------------------------|--------------------------------------------------------|
+| AlexNet                  | CNN        | Classic deep CNN architecture for image classification                  | [`paddlepaddle/cnn/alexnet_demo.py`](paddlepaddle/cnn/alexnet_demo.py) |
+| DenseNet                 | CNN        | Densely connected convolutional network for image classification        | [`paddlepaddle/cnn/densenet_demo.py`](paddlepaddle/cnn/densenet_demo.py) |
+| GoogLeNet                | CNN        | Inception architecture for image classification                         | [`paddlepaddle/cnn/googlenet_demo.py`](paddlepaddle/cnn/googlenet_demo.py) |
+| MobileNetV2              | CNN        | Lightweight CNN for mobile vision applications                          | [`paddlepaddle/cnn/mobilenetv2_demo.py`](paddlepaddle/cnn/mobilenetv2_demo.py) |
+| ResNet                   | CNN        | Deep residual network for image classification                          | [`paddlepaddle/cnn/resnet_demo.py`](paddlepaddle/cnn/resnet_demo.py) |
+| BLIP                     | Multimodal | Vision-language model for image captioning and understanding            | [`paddlepaddle/multimodal/blip_demo.py`](paddlepaddle/multimodal/blip_demo.py) |
 
 ## Running the Demos
 

--- a/demos/tt-forge-onnx/onnx/cnn/resnet_demo.py
+++ b/demos/tt-forge-onnx/onnx/cnn/resnet_demo.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+# ResNet ONNX Demo Script
+
+import onnx
+import onnxruntime as ort
+import torch
+
+import forge
+from third_party.tt_forge_models.resnet.pytorch import ModelLoader, ModelVariant
+
+
+def run_resnet_onnx(variant: ModelVariant):
+    """
+    Run a ResNet ONNX model
+    """
+
+    # Load Model and inputs using the ModelLoader
+    model_loader = ModelLoader(variant=variant)
+    pytorch_resnet_model = model_loader.load_model()
+    sample_input_tensor = model_loader.load_inputs()
+
+    # Export the PyTorch model to ONNX
+    onnx_model_path = f"resnet_{variant.value}.onnx"
+    torch.onnx.export(
+        pytorch_resnet_model,
+        sample_input_tensor,
+        onnx_model_path,
+        opset_version=17,
+    )
+
+    # Load and validate the exported ONNX model
+    onnx_model = onnx.load(onnx_model_path)
+    onnx.checker.check_model(onnx_model)
+
+    # Run ONNX reference inference (CPU) for comparison
+    ort_session = ort.InferenceSession(onnx_model_path)
+    input_name = ort_session.get_inputs()[0].name
+    onnx_output = ort_session.run(
+        None,
+        {input_name: sample_input_tensor.detach().numpy()},
+    )
+    onnx_predicted_index = onnx_output[0].argmax(-1).item()
+    onnx_predicted_class = pytorch_resnet_model.config.id2label[onnx_predicted_index]
+
+    # Compile the model
+    compiled_resnet_model = forge.compile(
+        onnx_model,
+        sample_inputs=[sample_input_tensor],
+    )
+
+    # Run inference
+    forge_output = compiled_resnet_model(sample_input_tensor)
+
+    # Post-process
+    forge_predicted_index = forge_output[0].argmax(-1).item()
+    forge_predicted_class = pytorch_resnet_model.config.id2label[forge_predicted_index]
+
+    print("[Result] Predicted classes:")
+    print(f"  ONNX (CPU reference) : {onnx_predicted_class}")
+    print(f"  Forge (Tenstorrent device)   : {forge_predicted_class}")
+
+
+if __name__ == "__main__":
+
+    demo_cases = [
+        ModelVariant.RESNET_50_HF,
+    ]
+
+    # Run each demo case
+    for variant in demo_cases:
+        run_resnet_onnx(variant)

--- a/demos/tt-forge-onnx/paddlepaddle/cnn/alexnet_demo.py
+++ b/demos/tt-forge-onnx/paddlepaddle/cnn/alexnet_demo.py
@@ -1,21 +1,38 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
-# Alexnet Demo Script
+# AlexNet PaddlePaddle Demo Script
 
 import forge
-from third_party.tt_forge_models.alexnet.image_classification.paddlepaddle import ModelLoader
+from third_party.tt_forge_models.alexnet.image_classification.paddlepaddle import ModelLoader, ModelVariant
 
-# Load model and input
-loader = ModelLoader()
-model = loader.load_model()
-inputs = loader.load_inputs()
 
-# Compile the model using Forge
-compiled_model = forge.compile(model, inputs)
+def run_alexnet_demo_case(variant):
+    """
+    Run an AlexNet PaddlePaddle model
+    """
 
-# Run inference on Tenstorrent device
-output = compiled_model(*inputs)
+    # Load Model and inputs using the ModelLoader
+    loader = ModelLoader(variant=variant)
+    model = loader.load_model()
+    inputs = loader.load_inputs()
 
-# Post-process the output
-loader.print_results(output)
+    # Compile the model
+    compiled_model = forge.compile(model, inputs)
+
+    # Run inference
+    output = compiled_model(*inputs)
+
+    # Post-process
+    loader.print_results(output)
+
+
+if __name__ == "__main__":
+
+    demo_cases = [
+        ModelVariant.DEFAULT,
+    ]
+
+    # Run each demo case
+    for variant in demo_cases:
+        run_alexnet_demo_case(variant)

--- a/demos/tt-forge-onnx/paddlepaddle/cnn/densenet_demo.py
+++ b/demos/tt-forge-onnx/paddlepaddle/cnn/densenet_demo.py
@@ -1,21 +1,38 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
-# Densenet Demo Script
+# DenseNet PaddlePaddle Demo Script
 
 import forge
-from third_party.tt_forge_models.densenet.image_classification.paddlepaddle import ModelLoader
+from third_party.tt_forge_models.densenet.image_classification.paddlepaddle import ModelLoader, ModelVariant
 
-# Load model and input
-loader = ModelLoader()
-model = loader.load_model()
-inputs = loader.load_inputs()
 
-# Compile the model using Forge
-compiled_model = forge.compile(model, inputs)
+def run_densenet_demo_case(variant):
+    """
+    Run a DenseNet PaddlePaddle model
+    """
 
-# Run inference on Tenstorrent device
-output = compiled_model(*inputs)
+    # Load Model and inputs using the ModelLoader
+    loader = ModelLoader(variant=variant)
+    model = loader.load_model()
+    inputs = loader.load_inputs()
 
-# Post-process the output
-loader.print_results(output)
+    # Compile the model
+    compiled_model = forge.compile(model, inputs)
+
+    # Run inference
+    output = compiled_model(*inputs)
+
+    # Post-process
+    loader.print_results(output)
+
+
+if __name__ == "__main__":
+
+    demo_cases = [
+        ModelVariant.DEFAULT,
+    ]
+
+    # Run each demo case
+    for variant in demo_cases:
+        run_densenet_demo_case(variant)

--- a/demos/tt-forge-onnx/paddlepaddle/cnn/googlenet_demo.py
+++ b/demos/tt-forge-onnx/paddlepaddle/cnn/googlenet_demo.py
@@ -1,21 +1,38 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
-# Googlenet Demo Script
+# GoogLeNet PaddlePaddle Demo Script
 
 import forge
-from third_party.tt_forge_models.googlenet.image_classification.paddlepaddle import ModelLoader
+from third_party.tt_forge_models.googlenet.image_classification.paddlepaddle import ModelLoader, ModelVariant
 
-# Load model and input
-loader = ModelLoader()
-model = loader.load_model()
-inputs = loader.load_inputs()
 
-# Compile the model using Forge
-compiled_model = forge.compile(model, inputs)
+def run_googlenet_demo_case(variant):
+    """
+    Run a GoogLeNet PaddlePaddle model
+    """
 
-# Run inference on Tenstorrent device
-output = compiled_model(*inputs)
+    # Load Model and inputs using the ModelLoader
+    loader = ModelLoader(variant=variant)
+    model = loader.load_model()
+    inputs = loader.load_inputs()
 
-# Post-process the output
-loader.print_results(output)
+    # Compile the model
+    compiled_model = forge.compile(model, inputs)
+
+    # Run inference
+    output = compiled_model(*inputs)
+
+    # Post-process
+    loader.print_results(output)
+
+
+if __name__ == "__main__":
+
+    demo_cases = [
+        ModelVariant.DEFAULT,
+    ]
+
+    # Run each demo case
+    for variant in demo_cases:
+        run_googlenet_demo_case(variant)

--- a/demos/tt-forge-onnx/paddlepaddle/cnn/mobilenetv2_demo.py
+++ b/demos/tt-forge-onnx/paddlepaddle/cnn/mobilenetv2_demo.py
@@ -1,21 +1,38 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
-# MobileNetV2 Demo Script
+# MobileNetV2 PaddlePaddle Demo Script
 
 import forge
-from third_party.tt_forge_models.mobilenetv2.image_classification.paddlepaddle import ModelLoader
+from third_party.tt_forge_models.mobilenetv2.image_classification.paddlepaddle import ModelLoader, ModelVariant
 
-# Load model and input
-loader = ModelLoader()
-model = loader.load_model()
-inputs = loader.load_inputs()
 
-# Compile the model using Forge
-compiled_model = forge.compile(model, inputs)
+def run_mobilenetv2_demo_case(variant):
+    """
+    Run a MobileNetV2 PaddlePaddle model
+    """
 
-# Run inference on Tenstorrent device
-output = compiled_model(*inputs)
+    # Load Model and inputs using the ModelLoader
+    loader = ModelLoader(variant=variant)
+    model = loader.load_model()
+    inputs = loader.load_inputs()
 
-# Post-process the output
-loader.print_results(output)
+    # Compile the model
+    compiled_model = forge.compile(model, inputs)
+
+    # Run inference
+    output = compiled_model(*inputs)
+
+    # Post-process
+    loader.print_results(output)
+
+
+if __name__ == "__main__":
+
+    demo_cases = [
+        ModelVariant.DEFAULT,
+    ]
+
+    # Run each demo case
+    for variant in demo_cases:
+        run_mobilenetv2_demo_case(variant)

--- a/demos/tt-forge-onnx/paddlepaddle/cnn/resnet_demo.py
+++ b/demos/tt-forge-onnx/paddlepaddle/cnn/resnet_demo.py
@@ -1,21 +1,42 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
-# ResNet Demo Script
+# ResNet PaddlePaddle Demo Script
 
 import forge
-from third_party.tt_forge_models.resnet.image_classification.paddlepaddle import ModelLoader
+from third_party.tt_forge_models.resnet.image_classification.paddlepaddle import ModelLoader, ModelVariant
 
-# Load model and input
-loader = ModelLoader()
-model = loader.load_model()
-inputs = loader.load_inputs()
 
-# Compile the model using Forge
-compiled_model = forge.compile(model, inputs)
+def run_resnet_demo_case(variant):
+    """
+    Run a ResNet PaddlePaddle model
+    """
 
-# Run inference on Tenstorrent device
-output = compiled_model(*inputs)
+    # Load Model and inputs using the ModelLoader
+    loader = ModelLoader(variant=variant)
+    model = loader.load_model()
+    inputs = loader.load_inputs()
 
-# Post-process the output
-loader.print_results(output)
+    # Compile the model
+    compiled_model = forge.compile(model, inputs)
+
+    # Run inference
+    output = compiled_model(*inputs)
+
+    # Post-process
+    loader.print_results(output)
+
+
+if __name__ == "__main__":
+
+    demo_cases = [
+        ModelVariant.RESNET18,
+        ModelVariant.RESNET34,
+        ModelVariant.RESNET50,
+        ModelVariant.RESNET101,
+        ModelVariant.RESNET152,
+    ]
+
+    # Run each demo case
+    for variant in demo_cases:
+        run_resnet_demo_case(variant)

--- a/demos/tt-forge-onnx/paddlepaddle/multimodal/blip_demo.py
+++ b/demos/tt-forge-onnx/paddlepaddle/multimodal/blip_demo.py
@@ -10,13 +10,16 @@ from third_party.tt_forge_models.blip.vision_language.paddlepaddle import ModelL
 
 
 def run_blip_demo_case(variant):
+    """
+    Run a BLIP PaddlePaddle model
+    """
 
     # Load model and input
     loader = ModelLoader(variant=variant)
     model = loader.load_model()
     inputs = loader.load_inputs()
 
-    # Compile the model using Forge
+    # Compile the model
     framework_model, _ = paddle_trace(model, inputs=inputs)
     compiled_model = forge.compile(framework_model, inputs)
 
@@ -36,15 +39,13 @@ def run_blip_demo_case(variant):
         for t, sim in zip(loader.text, similarities):
             print(f"{t}: similarity = {sim:.4f}")
 
-        # Compile model
+        # Compile the model
         framework_model, _ = paddle_trace(model, inputs=inputs)
         compiled_model = forge.compile(framework_model, inputs)
         outputs = compiled_model(*inputs)
     else:
-        # Run inference on Tenstorrent device
+        # Run inference
         outputs = compiled_model(*inputs)
-
-    print("=" * 60, flush=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR adds ResNet ONNX demos that were previously removed, updates PaddlePaddle demos to align with the standard format, updates the workflow to run ONNX and PaddlePaddle demos, and updates the README file.

## Changes

### ResNet ONNX Demo

Adds ResNet50 ONNX demos by converting the PyTorch ResNet50 model using the `torch.onnx.export` API, then compiling and executing the models.

### PaddlePaddle Demo Standardization

Updates all PaddlePaddle demos (`alexnet_demo.py`, `densenet_demo.py`, `googlenet_demo.py`, `mobilenetv2_demo.py`, and `resnet_demo.py` with support for multiple variants: RESNET18, RESNET34, RESNET50, RESNET101, RESNET152) to follow a consistent pattern with function-based organization.

### Workflow Updates

Updates `.github/workflows/models-matrix.json` to run the ONNX and PaddlePaddle models demos.