### PR TITLE
Rename matrix pytest calls

### DIFF
--- a/.github/workflows/perf-bench-matrix.json
+++ b/.github/workflows/perf-bench-matrix.json
@@ -131,7 +131,7 @@
       {
         "name": "mistral_small_24b_instruct_2501_tp",
         "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
-        "pytest": "benchmark/tt-xla/llms.py::test_mistral_small_24b_instruct_2501_tp",
+        "pytest": "benchmark/tt-xla/test_llms.py::test_mistral_small_24b_instruct_2501_tp",
         "runs-on": "llmbox"
       },
       {
@@ -143,13 +143,13 @@
       {
         "name": "qwen_2_5_32b_instruct_tp",
         "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
-        "pytest": "benchmark/tt-xla/llms.py::test_qwen_2_5_32b_instruct_tp",
+        "pytest": "benchmark/tt-xla/test_llms.py::test_qwen_2_5_32b_instruct_tp",
         "runs-on": "llmbox"
       },
       {
         "name": "qwen_2_5_coder_32b_instruct_tp",
         "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
-        "pytest": "benchmark/tt-xla/llms.py::test_qwen_2_5_coder_32b_instruct_tp",
+        "pytest": "benchmark/tt-xla/test_llms.py::test_qwen_2_5_coder_32b_instruct_tp",
         "runs-on": "llmbox"
       },
       {
@@ -179,7 +179,7 @@
       {
         "name": "qwen_3_32b_tp",
         "pyreq": "datasets loguru pytest requests tabulate timm torch==2.9.0 tqdm transformers==4.57.1",
-        "pytest": "benchmark/tt-xla/llms.py::test_qwen_3_32b_tp",
+        "pytest": "benchmark/tt-xla/test_llms.py::test_qwen_3_32b_tp",
         "runs-on": "llmbox"
       },
       {


### PR DESCRIPTION
`llms.py` is renamed to `test_llms.py`, so `.github/workflows/perf-bench-matrix.json` needs to change