### PR TITLE
Fix 3.11 references that were missed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,7 +164,7 @@ jobs:
       id: determine-docker-base-image
       run: |
         if [ "${{ steps.set-release-facts.outputs.python_version }}" == '3.12' ]; then
-          DOCKER_BASE_IMAGE="${{ steps.docker-build-push-3-11.outputs.image_tag }}"
+          DOCKER_BASE_IMAGE="${{ steps.docker-build-push-3-12.outputs.image_tag }}"
         fi
         echo "DOCKER_BASE_IMAGE=${DOCKER_BASE_IMAGE}"
         echo "DOCKER_BASE_IMAGE=${DOCKER_BASE_IMAGE}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Problem
During the switch from python3.11 to python3.12 there was a reference that was missed.

### Solution
Change the python version reference to point to python3.12.