### PR TITLE
Add README for tt-xla demos and clean up demos/README.md

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -16,5 +16,4 @@ Each frontend is designed to support different ML frameworks and workflows. Choo
 - Use TT-Forge-ONNX for quick deployment of pre-optimized common models for PaddlePaddle and ONNX. (Only single chip configurations are available. Also please note TT-Forge-ONNX can also be used for PyTorch, however it is recommended that you use TT-XLA for the best experience.)
 - Use TT-XLA for JAX model deployment as well as PyTorch (single and multi-chip configurations are available).
 
-
 For more information, visit our [GitHub repositories](https://github.com/tenstorrent) or check the README in each frontend's directory.

--- a/demos/README.md
+++ b/demos/README.md
@@ -1,5 +1,7 @@
 # TT-Forge Demos
 
+> **Prerequisites: Ubuntu 24.04 and Python 3.12.** See the [Getting Started guide](../docs/src/getting_started.md) for setup instructions.
+
 This directory contains demonstration examples for three different frontends available for Tenstorrent hardware:
 
 ## Available Frontends

--- a/demos/tt-xla/README.md
+++ b/demos/tt-xla/README.md
@@ -1,0 +1,50 @@
+# TT-XLA Model Demos
+
+This directory contains demonstration examples for running PyTorch and JAX models on Tenstorrent hardware via the [TT-XLA](https://github.com/tenstorrent/tt-xla) frontend.
+
+TT-XLA is the primary frontend for PyTorch and JAX. It leverages a PJRT interface to integrate with TT-MLIR and Tenstorrent hardware, supporting both single and multi-chip configurations.
+
+## Directory Structure
+
+- **`cnn/`** - Computer vision models (PyTorch)
+- **`nlp/`** - Natural language processing models
+  - `pytorch/` - NLP models using PyTorch
+  - `jax/` - NLP models using JAX
+
+## Available Demos
+
+### CNN (PyTorch)
+
+| Model    | Description                                              | Demo Code                                        |
+|----------|----------------------------------------------------------|--------------------------------------------------|
+| ResNet   | Deep residual network for image classification (ResNet-18/34/50/101/152) | [`cnn/resnet_demo.py`](cnn/resnet_demo.py)       |
+| Arnold   | Reinforcement learning model for game environments       | [`cnn/arnold_demo.py`](cnn/arnold_demo.py)       |
+
+### NLP — PyTorch
+
+| Model       | Description                                                        | Demo Code                                                      |
+|-------------|---------------------------------------------------------------------|----------------------------------------------------------------|
+| ALBERT      | Lightweight BERT variant for masked LM, QA, token & sequence classification | [`nlp/pytorch/albert_demo.py`](nlp/pytorch/albert_demo.py)     |
+| BGE-M3      | Multi-lingual embedding model for dense, sparse, and ColBERT retrieval      | [`nlp/pytorch/bge3_demo.py`](nlp/pytorch/bge3_demo.py)         |
+| BGE-M3 Encode | BGE-M3 encode function for sentence similarity and lexical matching       | [`nlp/pytorch/bge3_encode_demo.py`](nlp/pytorch/bge3_encode_demo.py) |
+| OPT         | Open Pre-trained Transformer for causal LM, QA, and sequence classification | [`nlp/pytorch/opt_demo.py`](nlp/pytorch/opt_demo.py)           |
+
+### NLP — JAX
+
+| Model    | Description                                                  | Demo Code                                              |
+|----------|--------------------------------------------------------------|--------------------------------------------------------|
+| ALBERT   | Lightweight BERT variant for masked language modeling        | [`nlp/jax/albert_demo.py`](nlp/jax/albert_demo.py)     |
+| GPT-2    | Autoregressive language model for text generation (Base/Medium/Large/XL) | [`nlp/jax/gpt_demo.py`](nlp/jax/gpt_demo.py)           |
+| OPT      | Open Pre-trained Transformer for causal language modeling    | [`nlp/jax/opt_demo.py`](nlp/jax/opt_demo.py)           |
+
+## Running the Demos
+
+For details about how to set up an environment and run a demo, please see the [TT-Forge Getting Started](../../docs/src/getting_started.md) page.
+
+If you encounter any issues or have questions, please file them at [github.com/tenstorrent/tt-forge/issues](https://github.com/tenstorrent/tt-forge/issues).
+
+## Additional Resources
+
+- [TT-XLA Documentation](https://docs.tenstorrent.com/tt-xla)
+- [Getting Started Guide](https://docs.tenstorrent.com/tt-xla/getting_started.html)
+- [TT-XLA GitHub Repository](https://github.com/tenstorrent/tt-xla)

--- a/demos/tt-xla/README.md
+++ b/demos/tt-xla/README.md
@@ -39,6 +39,9 @@ TT-XLA is the primary frontend for PyTorch and JAX. It leverages a PJRT interfac
 
 ## Running the Demos
 
+> **Prerequisites: Ubuntu 24.04 and Python 3.12.**
+> Using an older Python version (e.g. 3.10) will result in `jax` installation errors.
+
 For details about how to set up an environment and run a demo, please see the [TT-Forge Getting Started](../../docs/src/getting_started.md) page.
 
 If you encounter any issues or have questions, please file them at [github.com/tenstorrent/tt-forge/issues](https://github.com/tenstorrent/tt-forge/issues).


### PR DESCRIPTION
## Summary
- Add `demos/tt-xla/README.md` with directory structure, available demos table (CNN, NLP PyTorch, NLP JAX), run instructions, and links to documentation
- Remove deprecated tt-torch references from `demos/README.md`

## Changes
- **`demos/tt-xla/README.md`** (new) — Documents all 9 TT-XLA demo scripts organized by category, includes setup instructions pointing to the Getting Started guide, and links to TT-XLA docs
- **`demos/README.md`** — Removed deprecated tt-torch frontend section and references

## Why
The `demos/tt-xla/` directory had no README to discover and run the available demos. This adds clear documentation following the same pattern as the existing `demos/tt-forge-onnx/README.md`.