### PR TITLE
Stop tt-forge-onnx nightly releases

### DIFF
--- a/.github/actions/set-release-facts/action.yaml
+++ b/.github/actions/set-release-facts/action.yaml
@@ -154,7 +154,7 @@ runs:
         # Full repository name with "tenstorrent/" prefix
         repo_full="tenstorrent/${repo_short}"
         # List of all repos that will release nightly on a schedule
-        schedule_nightly_repos='tenstorrent/tt-forge-onnx'
+        schedule_nightly_repos=''
         # List of repos that are allowed to update RC and Stable releases on a schedule
         schedule_rc_stable_update_repos='tenstorrent/tt-forge-onnx tenstorrent/tt-xla tenstorrent/tt-forge'
         # Allow workflow failures when finding build workflows


### PR DESCRIPTION
### Problem
With this [PR](https://github.com/tenstorrent/tt-forge-onnx/pull/3277) tt-forge-onnx now completely handles it's own releasae process itself.

### Solution
TT-forge is no longer releasing tt-forge-onnx.

Note: This PR only removes the release trigger, but once 1 successful nigthly release has passed on tt-forge-onnx the entire release process will be removed from tt-forge in a separate PR.