### PR TITLE
Update requirements to uplift PyTorch

### DIFF
--- a/demos/tt-xla/cnn/requirements.txt
+++ b/demos/tt-xla/cnn/requirements.txt
@@ -1,7 +1,7 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 transformers==4.57.1
 datasets
-torch==2.9.0+cpu
+torch==2.10.0+cpu
 torchvision
 timm
 tabulate

--- a/demos/tt-xla/nlp/jax/requirements.txt
+++ b/demos/tt-xla/nlp/jax/requirements.txt
@@ -1,9 +1,9 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 jax==0.7.1
 transformers==4.57.1
-torch==2.9.0+cpu
+torch==2.10.0+cpu
 sentencepiece
 flax
-torchvision==0.24.0+cpu
+torchvision==0.25.0+cpu
 git+https://github.com/erfanzar/EasyDeL.git@77ced9d2f2ab6a3d705936d26112eb97d9f9e64a
 eformer==0.0.62


### PR DESCRIPTION
PyTorch is uplifted for tt-xla in https://github.com/tenstorrent/tt-xla/issues/4561
We need to update the requirements for tt-xla demos accordingly.