### PR TITLE
Align repo-local Ubuntu guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -38,7 +38,7 @@ body:
       description: |
         Details about your issue.
       placeholder: |
-        - OS version (e.g. Ubuntu 22.04)
+        - OS version (e.g. Ubuntu 22.04 LTS or Ubuntu 24.04)
         - Python version
         - Framework version (e.g. JAX version)
         - Version of software (e.g. release wheel or commit ID if you built from source)

--- a/README.md
+++ b/README.md
@@ -37,13 +37,18 @@ Models like GPT-OSS 120B, Llama 3 70B, Stable Diffusion XL, Whisper, and YOLOv12
 Get ResNet-50 running on Tenstorrent hardware in minutes:
 
 ```bash
-# Requires Ubuntu 24.04 and Python 3.12
+# Quickstart validated on Ubuntu 24.04 and Python 3.12
 python3.12 -m venv tt-forge-env
 source tt-forge-env/bin/activate
 pip install tt-forge --extra-index-url https://pypi.eng.aws.tenstorrent.com/
 tt-forge-install
 pip install torchvision
 ```
+
+> **Note:** These quickstart steps were validated on Ubuntu 24.04 with Python 3.12.
+> The main Tenstorrent software installation guide may recommend a different Ubuntu
+> LTS release for the broader software stack. Follow the frontend-specific install
+> guide if you need a different supported environment.
 
 ```python
 import torch

--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ pip install torchvision
 ```
 
 > **Note:** These quickstart steps were validated on Ubuntu 24.04 with Python 3.12.
-> The main Tenstorrent software installation guide may recommend a different Ubuntu
-> LTS release for the broader software stack. Follow the frontend-specific install
-> guide if you need a different supported environment.
+> The main Tenstorrent software installation guide currently recommends Ubuntu
+> 22.04 LTS for the broader software stack. Follow the frontend-specific install
+> guide if you need to match that wider environment recommendation.
 
 ```python
 import torch

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -13,7 +13,12 @@ This document walks you through how to set up to run demo models using TT-Forge.
 
 ## Setting up a Front End to Run a Demo
 
-**Requirements:** Ubuntu 24.04, Python 3.12.
+**Validated environment for this quickstart:** Ubuntu 24.04, Python 3.12.
+
+> **NOTE:** These demo steps were validated on Ubuntu 24.04 with Python 3.12.
+> The broader Tenstorrent software installation docs may recommend a different
+> Ubuntu LTS release for other workflows. Follow the frontend-specific install
+> guide if you need a different supported environment.
 
 This section provides instructions for how to set up your frontend so you can run models from the TT-Forge repo.
 

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -16,9 +16,9 @@ This document walks you through how to set up to run demo models using TT-Forge.
 **Validated environment for this quickstart:** Ubuntu 24.04, Python 3.12.
 
 > **NOTE:** These demo steps were validated on Ubuntu 24.04 with Python 3.12.
-> The broader Tenstorrent software installation docs may recommend a different
-> Ubuntu LTS release for other workflows. Follow the frontend-specific install
-> guide if you need a different supported environment.
+> The broader Tenstorrent software installation docs currently recommend Ubuntu
+> 22.04 LTS for other workflows. Follow the frontend-specific install guide if
+> you need to match that wider environment recommendation.
 
 This section provides instructions for how to set up your frontend so you can run models from the TT-Forge repo.
 


### PR DESCRIPTION
Ticket
#1010

Summary
Align the repo-local Ubuntu guidance so the quickstart docs state the environment this repository validated instead of presenting Ubuntu 24.04 as a global requirement.

This change does three things:
- rewrites the README quickstart note from a hard requirement to a validated environment statement
- does the same in docs/src/getting_started.md and names the current broader Tenstorrent recommendation of Ubuntu 22.04 LTS for the wider software stack
- updates the bug template OS example so issue reports no longer imply that only Ubuntu 22.04 is relevant

Notes for reviewers
The issue was not that tt-forge mentioned Ubuntu 24.04. The issue was that the repo stated Ubuntu 24.04 as a requirement while the broader Tenstorrent installation docs currently recommend Ubuntu 22.04 LTS.

I kept this PR repo-local on purpose. It aligns the wording in tt-forge without trying to change the main docs site from here.

Validation
- /home/peter/.local/mdbook-0.4.40/bin/mdbook build docs
- source /home/peter/.venvs/tt-forge-tools/bin/activate && pre-commit run --files README.md docs/src/getting_started.md .github/ISSUE_TEMPLATE/bug_report.yml
- git diff --check
